### PR TITLE
fix: maintain frontdoor tags

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -211,8 +211,13 @@ func (fd *AzureFrontDoor) update() int {
 
 	azfd := frontdoor.NewPoliciesClient(fd.SubscriptionId)
 	azfd.Authorizer, _ = a.authorize()
+
+	// Read current state of azure frontdoor
+	azfdget, _ := azfd.Get(context.Background(), fd.ResourceGroup, fd.PolicyName)
+
 	_, err := azfd.CreateOrUpdate(context.Background(), fd.ResourceGroup, fd.PolicyName, frontdoor.WebApplicationFirewallPolicy{
 		Location: to.StringPtr("Global"),
+		Tags:     azfdget.Tags, // Preserve tags for existing policies.
 		WebApplicationFirewallPolicyProperties: &frontdoor.WebApplicationFirewallPolicyProperties{
 			PolicySettings: &frontdoor.PolicySettings{
 				EnabledState:                  frontdoor.PolicyEnabledStateEnabled,

--- a/terraform/frontdoor.tf
+++ b/terraform/frontdoor.tf
@@ -12,6 +12,11 @@ resource "azurerm_frontdoor_firewall_policy" "this" {
     https://xyz.com/ip-whitelister
   */
   lifecycle { ignore_changes = [custom_rule, managed_rule] }
+
+  tags = {
+    name       = var.name
+    created-by = "terraform"
+  }
 }
 
 output "azure_frontdoor_policy" {


### PR DESCRIPTION
Closes: #61 

✋ **Disclaimer**: I don't get to write a lot of golang at the moment, please provide feedback if there's issues with my proposed fix.

### Changes

1. Add variable to read existing Front Door policy using [`PoliciesClient.Get()`](https://pkg.go.dev/github.com/Azure/Azure-sdk-for-go@v60.3.0+incompatible/services/frontdoor/mgmt/2019-10-01/frontdoor#PoliciesClient.Get).
2. Set `Tags` to the value returned by `PoliciesClient.Get()`

### Testing

1. Build the infra in `./terraform`
2. Check the tags on the Azure Front Door WAF policy exist in Azure Portal
3. Configure the config file `./config/config.yaml` as per the Terraform and service principal (I also did `rm ./config/resources/*.yaml` for testing).
4. Run `go build`
5. Run `./ip-whitelister`
6. Re-check the tags on the Azure Front Door WAF policy exist in Azure Portal - the tags should remain.