### PR TITLE
test: Tier 1 coverage gaps + fix bare-IP ip_whitelist match

### DIFF
--- a/functions_test.go
+++ b/functions_test.go
@@ -65,6 +65,9 @@ func TestHasGroup(t *testing.T) {
 		{[]string{"group1", "group2"}, []string{"group6", "group2"}, true},
 		{[]string{"group1"}, []string{"group9", "group10", "group11"}, false},
 		{[]string{"group1", "group2", "group3", "group4"}, []string{"group5"}, false},
+		// a resource with no group restriction (nil) is open to everyone
+		{nil, []string{"group1"}, true},
+		{nil, nil, true},
 	}
 
 	for _, f := range groups {
@@ -146,6 +149,13 @@ func TestAddNetmask(t *testing.T) {
 		if ipWithMask != f.ipWithMask {
 			t.Errorf("addNetmask for %v was incorrect, got %v, want %v", f, ipWithMask, f.ipWithMask)
 		}
+	}
+}
+
+func TestAddNetmaskInvalid(t *testing.T) {
+	// an unparseable address cannot have a netmask inferred and must error
+	if _, err := addNetmask("not-an-ip"); err == nil {
+		t.Errorf("addNetmask for an unparseable value should return an error")
 	}
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/gob"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -164,5 +165,52 @@ func TestIndexHandler(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "Whitelisting your IP") {
 		t.Errorf("IndexHandler(new=true) body missing the whitelisting message")
+	}
+}
+
+func TestIndexHandlerWithToken(t *testing.T) {
+	// Minimal wiring normally done by Authentication.init / initAzure.
+	gob.Register(&oauth2.Token{})
+	store = sessions.NewFilesystemStore(t.TempDir(), sessionStoreKeyPairs...)
+	oauthConfig = &oauth2.Config{
+		ClientID:    "test-client",
+		RedirectURL: "http://localhost/callback",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://login.example.com/authorize",
+			TokenURL: "https://login.example.com/token",
+		},
+	}
+
+	// Populate a session with a token + ip, as callbackHandler would, and
+	// capture the resulting session cookie.
+	saveReq := httptest.NewRequest("GET", "/", nil)
+	saveRR := httptest.NewRecorder()
+	session, _ := store.Get(saveReq, "session")
+	session.Values["token"] = &oauth2.Token{AccessToken: "test-access-token"}
+	session.Values["ip_address"] = "203.0.113.7"
+	if err := sessions.Save(saveReq, saveRR); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	// Replay the cookie so IndexHandler takes the token-present branch.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, cookie := range saveRR.Result().Cookies() {
+		req.AddCookie(cookie)
+	}
+	if err := IndexHandler(rr, req); err != nil {
+		t.Fatalf("IndexHandler() unexpected error: %v", err)
+	}
+
+	body := rr.Body.String()
+	// the token branch renders the "Whitelist again" link and the whitelisted IP
+	if !strings.Contains(body, "Whitelist again") {
+		t.Errorf("IndexHandler() with token missing the 'Whitelist again' link:\n%s", body)
+	}
+	if !strings.Contains(body, "203.0.113.7") {
+		t.Errorf("IndexHandler() with token missing the whitelisted IP:\n%s", body)
+	}
+	if strings.Contains(body, "Whitelisting your IP") {
+		t.Errorf("IndexHandler() with token should not render the redirect branch:\n%s", body)
 	}
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -242,6 +242,54 @@ func TestAddGroups(t *testing.T) {
 	DeleteTestRedis(t, testRedisInstance)
 }
 
+func TestApiThrottle(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	ret := r.connect(rc)
+	if ret == true {
+		const user = "testuser111111"
+
+		// a user that has never called the api may call it
+		if !r.canCallApi(user) {
+			t.Errorf("redis.canCallApi(): fresh user %q, got 'false', want 'true'", user)
+		}
+
+		// after recording a call, the user is throttled
+		r.apiCalled(user)
+		if r.canCallApi(user) {
+			t.Errorf("redis.canCallApi(): throttled user %q, got 'true', want 'false'", user)
+		}
+
+		// a different user is unaffected by the throttle
+		if !r.canCallApi("testuser222222") {
+			t.Errorf("redis.canCallApi(): unrelated user, got 'false', want 'true'")
+		}
+	}
+
+	DeleteTestRedis(t, testRedisInstance)
+}
+
+func TestGetGroupsMissing(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	ret := r.connect(rc)
+	if ret == true {
+		// a user with no cached groups returns an empty slice, not an error
+		groups := r.getGroups("testuser-does-not-exist")
+		if len(groups) != 0 {
+			t.Errorf("redis.getGroups(): missing user, got '%v', want empty", groups)
+		}
+	}
+
+	DeleteTestRedis(t, testRedisInstance)
+}
+
 func TestGetGroups(t *testing.T) {
 	users := []struct {
 		user    string

--- a/whitelist.go
+++ b/whitelist.go
@@ -135,6 +135,7 @@ func (*Whitelist) inRange(ip string, whitelist []string) bool {
 				if c.Debug {
 					log.Printf("whitelist.inRange(): IPAddress value %v overlaps with already whitelisted value %v", ip, v)
 				}
+				return true
 			}
 		}
 	}

--- a/whitelist_test.go
+++ b/whitelist_test.go
@@ -108,6 +108,10 @@ func TestInRange(t *testing.T) {
 		{Whitelist{map[string]string{"alecpinson123456": "123.123.123.123/32"}}, "2a00:11c7:1234:b801:a16e:12af:5e42:1100/32", []string{"1.2.3.0/24"}, false},
 		// ipv6 with an empty static whitelist
 		{Whitelist{map[string]string{"alecpinson123456": "123.123.123.123/32"}}, "2a00:11c7:1234:b801:a16e:12af:5e42:1111/32", []string{}, false},
+		// a bare (non-CIDR) static whitelist entry that exactly matches
+		{Whitelist{map[string]string{"alecpinson123456": "123.123.123.123/32"}}, "203.0.113.5", []string{"203.0.113.5"}, true},
+		// a bare static whitelist entry that does not match
+		{Whitelist{map[string]string{"alecpinson123456": "123.123.123.123/32"}}, "203.0.113.6", []string{"203.0.113.5"}, false},
 	}
 
 	for _, f := range tests {


### PR DESCRIPTION
## Summary
Fills the "Tier 1" (pure-Go and Redis-backed) test coverage gaps and fixes a latent bug found along the way. Coverage: **46.0% → 47.7%**.

## Bug fix (`fix:` commit)
`whitelist.go:inRange` — a bare (non-CIDR) entry in `ip_whitelist` that exactly matched a user's IP logged an overlap but fell through to `return false`, so plain-IP static whitelist entries never suppressed dynamic whitelisting (only CIDR entries did). Now returns `true` on an exact bare-IP match, mirroring the CIDR branch.

- Before: `ip_whitelist: ["203.0.113.5"]` + user IP `203.0.113.5` → still written to Redis and pushed to every Azure resource.
- After: correctly treated as already whitelisted, `add()` returns early.
- Workaround was to write entries as `203.0.113.5/32`.

## Tests added (`test:` commit)
- **functions**: `hasGroup` nil-restriction branch, `addNetmask` error path
- **redis**: `TestApiThrottle` (covers previously-untested `canCallApi` + `apiCalled`), `TestGetGroupsMissing`
- **http**: `TestIndexHandlerWithToken` covers the token-present render branch
- **whitelist**: bare-IP match / non-match cases in `TestInRange`

## Coverage deltas
| Function | Before | After |
|---|---|---|
| `hasGroup` | 85.7% | 100% |
| `addNetmask` | 87.5% | 100% |
| `IndexHandler` | 84.6% | 100% |
| `inRange` | 66.7% | 84.6% |
| `canCallApi` | 0% | 71.4% |

`go test ./...`, `go vet ./...` and `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)