### PR TITLE
feat: add auth.type none (proxy-trusted / no-auth mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ ip-whitelister-secrets.yaml
 helm/values.yaml
 .hq-docs/
 ip-whitelister
+config.dev

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Key top-level options:
 | -------------- | ------------------------------------------------------------------ |
 | `url`          | Public base URL of the app (used to build the OAuth callback).     |
 | `ttl`          | Whitelist lifetime in hours (default `24`).                        |
-| `auth`         | AzureAD tenant/client credentials (`type: azure`).                 |
+| `auth`         | Authentication mode: `type: azure` (AzureAD OAuth) or `type: none` (disable in-app auth — see [Disabling auth](#disabling-auth-reverse-proxy-sso)). |
 | `redis`        | Redis `host`, `port`, and `token`.                                 |
 | `unifi`        | UniFi gateway connection + credentials (see [UniFi](#unifi)).       |
 | `resources`    | List of cloud resources to whitelist against (see example config). |
@@ -85,6 +85,29 @@ Sensitive values can be injected via env vars, overriding the YAML:
 > `tenant_id` is left as the placeholder value from the sample config, and UniFi
 > syncing is skipped while `unifi.host` is empty or contains `notreal`, so the
 > dummy config never touches real cloud resources or a real gateway.
+
+### Disabling auth (reverse-proxy SSO)
+
+If you run ip-whitelister behind an SSO reverse proxy (e.g. Cloudflare Access,
+Authelia, oauth2-proxy) you can disable the built-in AzureAD login and let the
+proxy handle authentication:
+
+```yaml
+auth:
+  type: none   # alias: disabled
+  # header: Cf-Access-Authenticated-User-Email   # trusted identity header (default shown)
+```
+
+In this mode any request to `/` immediately whitelists the caller's IP and shows
+a confirmation page — there is no OAuth redirect or callback. The whitelist
+entry is keyed on the identity the proxy supplies in the configured `header`
+(default `Cf-Access-Authenticated-User-Email`); if that header is absent the
+entry is keyed on the client IP instead.
+
+Because AzureAD group membership is unavailable without OAuth, **group-scoped
+resources are skipped** in this mode — only resources without a `group:` filter
+are whitelisted. `tenant_id`, `client_id` and `client_secret` are ignored and
+can be omitted.
 
 ### UniFi
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ proxy handle authentication:
 ```yaml
 auth:
   type: none   # alias: disabled
-  # header: Cf-Access-Authenticated-User-Email   # trusted identity header (default shown)
+  # header:    Cf-Access-Authenticated-User-Email   # trusted identity header (default shown)
+  # ip_header: Cf-Connecting-Ip                      # trusted client-IP header (default shown)
 ```
 
 In this mode any request to `/` immediately whitelists the caller's IP and shows
@@ -103,6 +104,12 @@ a confirmation page — there is no OAuth redirect or callback. The whitelist
 entry is keyed on the identity the proxy supplies in the configured `header`
 (default `Cf-Access-Authenticated-User-Email`); if that header is absent the
 entry is keyed on the client IP instead.
+
+The client IP is read from the `ip_header` request header (default
+`Cf-Connecting-Ip`, which Cloudflare sets). **Your proxy MUST set this header to
+the real client IP and strip any client-supplied value** — otherwise an
+authenticated user could spoof it to whitelist an arbitrary address. For Azure
+Front Door use `ip_header: X-Azure-Clientip`.
 
 Because AzureAD group membership is unavailable without OAuth, **group-scoped
 resources are skipped** in this mode — only resources without a `group:` filter

--- a/config.go
+++ b/config.go
@@ -73,6 +73,9 @@ func applyAuthDefaults(a Authentication) Authentication {
 		if a.Header == "" {
 			a.Header = "Cf-Access-Authenticated-User-Email"
 		}
+		if a.IPHeader == "" {
+			a.IPHeader = "Cf-Connecting-Ip"
+		}
 	}
 	return a
 }

--- a/config.go
+++ b/config.go
@@ -64,6 +64,19 @@ func applyDefaults(resources []ResourceConfiguration, d Defaults) {
 	}
 }
 
+// applyAuthDefaults fills in auth defaults. When auth is disabled
+// (type none/disabled) and no identity header is configured, it defaults to the
+// header set by Cloudflare Access.
+func applyAuthDefaults(a Authentication) Authentication {
+	switch strings.ToLower(a.Type) {
+	case "none", "disabled":
+		if a.Header == "" {
+			a.Header = "Cf-Access-Authenticated-User-Email"
+		}
+	}
+	return a
+}
+
 func (c *Configuration) load(reload ...bool) *Configuration {
 	if strings.ToLower(os.Getenv("DEBUG")) == "true" {
 		c.Debug = true
@@ -95,6 +108,8 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 	if c.TTL == 0 {
 		c.TTL = 24
 	}
+
+	c.Auth = applyAuthDefaults(c.Auth)
 
 	if c.Unifi.Site == "" {
 		c.Unifi.Site = "default"

--- a/config_test.go
+++ b/config_test.go
@@ -51,6 +51,29 @@ func TestApplyDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyAuthDefaults(t *testing.T) {
+	cases := []struct {
+		name   string
+		typ    string
+		header string
+		want   string
+	}{
+		{"none defaults the cloudflare header", "none", "", "Cf-Access-Authenticated-User-Email"},
+		{"disabled alias defaults too", "disabled", "", "Cf-Access-Authenticated-User-Email"},
+		{"case-insensitive type", "None", "", "Cf-Access-Authenticated-User-Email"},
+		{"explicit header is kept", "none", "X-My-Header", "X-My-Header"},
+		{"azure is unaffected", "azure", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyAuthDefaults(Authentication{Type: tc.typ, Header: tc.header})
+			if got.Header != tc.want {
+				t.Errorf("header = %q, want %q", got.Header, tc.want)
+			}
+		})
+	}
+}
+
 func TestUnifiConfigLoad(t *testing.T) {
 	t.Setenv("UNIFI_USERNAME", "envuser")
 	t.Setenv("UNIFI_PASSWORD", "envpass")

--- a/config_test.go
+++ b/config_test.go
@@ -53,22 +53,27 @@ func TestApplyDefaults(t *testing.T) {
 
 func TestApplyAuthDefaults(t *testing.T) {
 	cases := []struct {
-		name   string
-		typ    string
-		header string
-		want   string
+		name         string
+		typ          string
+		header       string
+		ipHeader     string
+		wantHeader   string
+		wantIPHeader string
 	}{
-		{"none defaults the cloudflare header", "none", "", "Cf-Access-Authenticated-User-Email"},
-		{"disabled alias defaults too", "disabled", "", "Cf-Access-Authenticated-User-Email"},
-		{"case-insensitive type", "None", "", "Cf-Access-Authenticated-User-Email"},
-		{"explicit header is kept", "none", "X-My-Header", "X-My-Header"},
-		{"azure is unaffected", "azure", "", ""},
+		{"none defaults both headers", "none", "", "", "Cf-Access-Authenticated-User-Email", "Cf-Connecting-Ip"},
+		{"disabled alias defaults too", "disabled", "", "", "Cf-Access-Authenticated-User-Email", "Cf-Connecting-Ip"},
+		{"case-insensitive type", "None", "", "", "Cf-Access-Authenticated-User-Email", "Cf-Connecting-Ip"},
+		{"explicit headers are kept", "none", "X-My-Id", "X-My-Ip", "X-My-Id", "X-My-Ip"},
+		{"azure is unaffected", "azure", "", "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := applyAuthDefaults(Authentication{Type: tc.typ, Header: tc.header})
-			if got.Header != tc.want {
-				t.Errorf("header = %q, want %q", got.Header, tc.want)
+			got := applyAuthDefaults(Authentication{Type: tc.typ, Header: tc.header, IPHeader: tc.ipHeader})
+			if got.Header != tc.wantHeader {
+				t.Errorf("header = %q, want %q", got.Header, tc.wantHeader)
+			}
+			if got.IPHeader != tc.wantIPHeader {
+				t.Errorf("ipHeader = %q, want %q", got.IPHeader, tc.wantIPHeader)
 			}
 		})
 	}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  ip-whitelister:
+    build: .
+    volumes:
+      - ./config.dev:/app/config:ro
+    ports:
+      - "8082:8080"
+    restart: always
+    environment:
+      CONFIG_FILE: "/app/config/config.yaml"
+  redis:
+    image: redis:6.2.6-alpine
+    volumes:
+      - ./config.dev:/usr/local/etc/redis:ro
+    command: redis-server /usr/local/etc/redis/redis.conf

--- a/docs/superpowers/plans/2026-07-02-disable-auth-none.md
+++ b/docs/superpowers/plans/2026-07-02-disable-auth-none.md
@@ -1,0 +1,620 @@
+# Disable auth (`auth.type: none`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a no-auth mode (`auth.type: none`) so the app can run behind an external SSO reverse proxy (e.g. Cloudflare Access) instead of doing its own AzureAD OAuth login.
+
+**Architecture:** Additive change on the existing `switch auth.type` seam. A new `none`/`disabled` case registers a minimal handler that whitelists the caller's IP directly from request headers — no OAuth redirect, callback, or Graph API call. Identity comes from a configurable trusted header (default `Cf-Access-Authenticated-User-Email`), falling back to the IP. No-auth users get empty `groups`, so the existing `hasGroup` logic skips group-scoped resources for free.
+
+**Tech Stack:** Go (flat `package main`), `net/http` + `html/template`, `gorilla/sessions` (OAuth path only), `redigo` for Redis. Tests use `net/http/httptest`; the no-auth unit tests reuse the existing `stubRedis()` fake and need no Docker.
+
+Spec: `docs/superpowers/specs/2026-07-02-disable-auth-none-provider-design.md`
+
+---
+
+## File Structure
+
+- `http.go` — add `Header` field to `Authentication`; add `none`/`disabled` case to `init`; add `initNoAuth`, `noAuthIndexHandler`, and a confirmation template `noAuthTempl`.
+- `user.go` — extract shared request-derived logic into `finishUser`; add `newFromRequest`.
+- `config.go` — add `applyAuthDefaults` and call it in `load`.
+- `config_test.go` / `user_test.go` / `http_test.go` — new unit tests.
+- `README.md` — document `auth.type: none`.
+
+All new tests use `-run <TestName> .` so they never spin the Docker-backed Redis suite.
+
+---
+
+### Task 1: `Authentication.Header` field + config default
+
+**Files:**
+- Modify: `http.go` (the `Authentication` struct, ~L114-119)
+- Modify: `config.go` (add `applyAuthDefaults`, call in `load`)
+- Test: `config_test.go`
+
+- [ ] **Step 1: Add the `Header` field to the struct**
+
+In `http.go`, change the `Authentication` struct to add the `Header` field:
+
+```go
+type Authentication struct {
+	Type         string `yaml:"type"`
+	Header       string `yaml:"header"`
+	TenantId     string `yaml:"tenant_id"`
+	ClientId     string `yaml:"client_id"`
+	ClientSecret string `yaml:"client_secret"`
+}
+```
+
+- [ ] **Step 2: Write the failing test for the default helper**
+
+Add to `config_test.go`:
+
+```go
+func TestApplyAuthDefaults(t *testing.T) {
+	cases := []struct {
+		name   string
+		typ    string
+		header string
+		want   string
+	}{
+		{"none defaults the cloudflare header", "none", "", "Cf-Access-Authenticated-User-Email"},
+		{"disabled alias defaults too", "disabled", "", "Cf-Access-Authenticated-User-Email"},
+		{"case-insensitive type", "None", "", "Cf-Access-Authenticated-User-Email"},
+		{"explicit header is kept", "none", "X-My-Header", "X-My-Header"},
+		{"azure is unaffected", "azure", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyAuthDefaults(Authentication{Type: tc.typ, Header: tc.header})
+			if got.Header != tc.want {
+				t.Errorf("header = %q, want %q", got.Header, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test -run TestApplyAuthDefaults -v .`
+Expected: FAIL — `undefined: applyAuthDefaults`.
+
+- [ ] **Step 4: Implement `applyAuthDefaults` and wire it into `load`**
+
+In `config.go`, add the function (near `applyDefaults`, ~L56):
+
+```go
+// applyAuthDefaults fills in auth defaults. When auth is disabled
+// (type none/disabled) and no identity header is configured, it defaults to the
+// header set by Cloudflare Access.
+func applyAuthDefaults(a Authentication) Authentication {
+	switch strings.ToLower(a.Type) {
+	case "none", "disabled":
+		if a.Header == "" {
+			a.Header = "Cf-Access-Authenticated-User-Email"
+		}
+	}
+	return a
+}
+```
+
+Then in `Configuration.load`, right after the `yaml.Unmarshal` block that populates `c` (immediately after the `if c.TTL == 0 { ... }` block, ~L97), add:
+
+```go
+	c.Auth = applyAuthDefaults(c.Auth)
+```
+
+(`strings` is already imported in `config.go`.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test -run TestApplyAuthDefaults -v .`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the build and existing config tests still pass**
+
+Run: `go build . && go test -run 'TestLoad|TestUnifiConfigLoad|TestApplyDefaults' -v .`
+Expected: PASS (the sample config stays `type: azure`, so its `Header` stays empty).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add http.go config.go config_test.go
+git commit -m "feat: add auth.header field + default for auth.type none"
+```
+
+---
+
+### Task 2: Extract shared `finishUser` helper (refactor under existing tests)
+
+**Files:**
+- Modify: `user.go` (`User.new`, ~L89-118)
+- Guarded by: existing `user_test.go::TestUserNew`
+
+This task introduces no new behaviour — it moves the IP/cidr/key logic out of `new` into a reusable helper. `TestUserNew` is the safety net.
+
+- [ ] **Step 1: Add the `finishUser` helper**
+
+In `user.go`, add this method (e.g. just below `new`):
+
+```go
+// finishUser fills in the request-derived fields shared by both the OAuth and
+// no-auth constructors: the client IP (with a loopback override for local
+// testing), its cidr, and the whitelist key derived from identity. When
+// identity is empty the key falls back to the client IP.
+func (u *User) finishUser(identity string, req *http.Request) error {
+	// get ip
+	u.ip = req.Header.Get("X-Azure-Clientip")
+	if u.ip == "" {
+		var err error
+		u.ip, _, err = net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
+			log.Printf("user.finishUser(): %q is not IP:port\n", req.RemoteAddr)
+		}
+	}
+
+	// annoying when testing locally, make up an ip :)
+	if u.ip == "::1" {
+		u.ip = "80.18.81.18"
+	}
+
+	cidr, err := addNetmask(u.ip)
+	if err != nil {
+		return err
+	}
+	u.cidr = cidr
+
+	// Create our 'key' by removing spaces, lower-casing and stripping special
+	// characters. Fall back to the IP when there is no identity (no-auth mode).
+	if identity == "" {
+		identity = u.ip
+	}
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		return err
+	}
+	u.key = strings.ToLower(reg.ReplaceAllString(identity, ""))
+
+	return nil
+}
+```
+
+- [ ] **Step 2: Replace the inline block in `new` with a call to `finishUser`**
+
+In `user.go`, replace the block from the `// Create our 'key' ...` comment (~L89) down to and including the `u.cidr, err = addNetmask(...)` block (~L114) with:
+
+```go
+	// derive key, client IP, and cidr (shared with the no-auth path)
+	if err := u.finishUser(u.name+u.employeeId, req); err != nil {
+		log.Fatal("user.new(): ", err)
+	}
+```
+
+Leave the final `log.Println("user.new(): authentication successful ...")` line and `return u` exactly as they are.
+
+- [ ] **Step 3: Run the existing user tests to verify no regression**
+
+Run: `go test -run 'TestUserNew|TestUserNewErrorStatus' -v .`
+Expected: PASS — key/ip/cidr/groups unchanged for all three `TestUserNew` cases.
+
+- [ ] **Step 4: Verify the whole package still builds and vets cleanly**
+
+Run: `go build . && go vet .`
+Expected: no output (success).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user.go
+git commit -m "refactor: extract shared finishUser helper from User.new"
+```
+
+---
+
+### Task 3: `User.newFromRequest`
+
+**Files:**
+- Modify: `user.go` (add `newFromRequest`)
+- Test: `user_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `user_test.go`:
+
+```go
+func TestUserNewFromRequest(t *testing.T) {
+	c.Debug = false
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	defer func() { c.Auth.Header = "" }()
+
+	tests := []struct {
+		name       string
+		header     string // Cf-Access-Authenticated-User-Email value ("" = not set)
+		clientIP   string // X-Azure-Clientip value ("" = not set)
+		remoteAddr string
+		wantName   string
+		wantKey    string
+		wantIP     string
+		wantCidr   string
+	}{
+		{
+			name:       "identity from trusted header",
+			header:     "alice@example.com",
+			clientIP:   "1.2.3.4",
+			remoteAddr: "10.0.0.1:5555",
+			wantName:   "alice@example.com",
+			wantKey:    "aliceexamplecom",
+			wantIP:     "1.2.3.4",
+			wantCidr:   "1.2.3.4/32",
+		},
+		{
+			name:       "no header falls back to keying on IP",
+			header:     "",
+			clientIP:   "",
+			remoteAddr: "8.8.8.8:1234",
+			wantName:   "",
+			wantKey:    "8888",
+			wantIP:     "8.8.8.8",
+			wantCidr:   "8.8.8.8/32",
+		},
+		{
+			name:       "loopback is rewritten for local testing",
+			header:     "",
+			clientIP:   "::1",
+			remoteAddr: "[::1]:8080",
+			wantName:   "",
+			wantKey:    "80188118",
+			wantIP:     "80.18.81.18",
+			wantCidr:   "80.18.81.18/32",
+		},
+	}
+
+	for _, f := range tests {
+		t.Run(f.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = f.remoteAddr
+			if f.clientIP != "" {
+				req.Header.Set("X-Azure-Clientip", f.clientIP)
+			}
+			if f.header != "" {
+				req.Header.Set("Cf-Access-Authenticated-User-Email", f.header)
+			}
+
+			var u User
+			if got := u.newFromRequest(req); got == nil {
+				t.Fatalf("newFromRequest() returned nil, want a populated user")
+			}
+			if u.name != f.wantName {
+				t.Errorf("name: got %q, want %q", u.name, f.wantName)
+			}
+			if u.key != f.wantKey {
+				t.Errorf("key: got %q, want %q", u.key, f.wantKey)
+			}
+			if u.ip != f.wantIP {
+				t.Errorf("ip: got %q, want %q", u.ip, f.wantIP)
+			}
+			if u.cidr != f.wantCidr {
+				t.Errorf("cidr: got %q, want %q", u.cidr, f.wantCidr)
+			}
+			if u.groups != nil {
+				t.Errorf("groups: got %v, want nil", u.groups)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestUserNewFromRequest -v .`
+Expected: FAIL — `u.newFromRequest undefined`.
+
+- [ ] **Step 3: Implement `newFromRequest`**
+
+In `user.go`, add (below `finishUser`):
+
+```go
+// newFromRequest builds a User without OAuth, for auth.type: none. Identity
+// comes from the configured trusted header (set by an upstream SSO proxy such
+// as Cloudflare Access). Groups are unavailable, so u.groups stays nil and the
+// existing hasGroup logic skips group-scoped resources.
+func (u *User) newFromRequest(req *http.Request) *User {
+	var identity string
+	if c.Auth.Header != "" {
+		identity = req.Header.Get(c.Auth.Header)
+	}
+	if identity != "" {
+		u.name = identity
+	}
+
+	if err := u.finishUser(identity, req); err != nil {
+		log.Printf("user.newFromRequest(): %v", err)
+		return nil
+	}
+
+	log.Println("user.newFromRequest(): request accepted - " + u.name + " - " + u.ip)
+	return u
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestUserNewFromRequest -v .`
+Expected: PASS (all three sub-cases).
+
+- [ ] **Step 5: Add a `hasGroup` case proving empty-group users are skipped**
+
+No-auth users have `groups == nil`, so group-scoped resources must reject them.
+`TestHasGroup` (`functions_test.go`) has a non-matching case but no empty-user
+case. Add this line to the `groups` table in `functions_test.go` (after the
+existing `{[]string{"group1"}, []string{"group9", "group10", "group11"}, false},`
+line):
+
+```go
+		// a no-auth user has no groups -> group-scoped resources are skipped
+		{[]string{"group1"}, nil, false},
+```
+
+- [ ] **Step 6: Run the group test to verify it passes**
+
+Run: `go test -run TestHasGroup -v .`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add user.go user_test.go functions_test.go
+git commit -m "feat: add User.newFromRequest for no-auth mode"
+```
+
+---
+
+### Task 4: No-auth handler, template, and init case
+
+**Files:**
+- Modify: `http.go` (add `noAuthTempl`, `noAuthIndexHandler`, `initNoAuth`, switch case)
+- Test: `http_test.go`
+
+- [ ] **Step 1: Write the failing handler test**
+
+This test needs a real Redis: the handler calls `u.whitelist()` → `w.add()` →
+`r.getWhitelist()`, which `log.Fatal`s on any Redis error (so `stubRedis()`'s
+error-returning fake conn would kill the process). Mirror the `CreateTestRedis`
+pattern from `TestUserWhitelist` in `user_test.go`. Add to `http_test.go`:
+
+```go
+func TestNoAuthIndexHandler(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	// config is never loaded in tests; give redis keys a real TTL and set the
+	// trusted header the no-auth path reads.
+	c.TTL = 24
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	defer func() { c.Auth.Header = "" }()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "alice@example.com")
+	req.Header.Set("X-Azure-Clientip", "203.0.113.7")
+	rr := httptest.NewRecorder()
+
+	if err := noAuthIndexHandler(rr, req); err != nil {
+		t.Fatalf("noAuthIndexHandler() unexpected error: %v", err)
+	}
+
+	// the confirmation page shows the identity + whitelisted IP
+	body := rr.Body.String()
+	if !strings.Contains(body, "203.0.113.7") {
+		t.Errorf("body missing whitelisted IP:\n%s", body)
+	}
+	if !strings.Contains(body, "alice@example.com") {
+		t.Errorf("body missing identity:\n%s", body)
+	}
+	if !strings.Contains(body, "has been whitelisted") {
+		t.Errorf("body missing confirmation text:\n%s", body)
+	}
+	// no-auth mode must never render the OAuth redirect branch
+	if strings.Contains(body, "Whitelisting your IP") {
+		t.Errorf("body unexpectedly rendered the OAuth redirect branch:\n%s", body)
+	}
+
+	// and the IP was actually stored, keyed on the header-derived identity
+	if got := r.getWhitelist()["aliceexamplecom"]; got != "203.0.113.7/32" {
+		t.Errorf("redis whitelist entry = %q, want %q", got, "203.0.113.7/32")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestNoAuthIndexHandler -v .`
+Expected: FAIL — `undefined: noAuthIndexHandler` (compile error).
+
+- [ ] **Step 3: Add the confirmation template**
+
+In `http.go`, add near the existing `indexTempl` var:
+
+```go
+var noAuthTempl = template.Must(template.New("").Parse(`<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dynamic IP Whitelist</title>
+
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  </head>
+  <body class="container-fluid">
+    <div class="row">
+      <div class="col-xs-4 col-xs-offset-4">
+        <h1>Dynamic IP Whitelist</h1>
+        Welcome{{with .Name}} {{.}}{{end}}, your IP ({{.IPAddress}}) has been whitelisted.
+        <br>
+        <i>Note: It can take a few minutes for your whitelisting to become active. Please note that IPv6 cannot be whitelisted on all resources.</i>
+      </div>
+    </div>
+  </body>
+</html>
+`))
+```
+
+- [ ] **Step 4: Add the handler and init function**
+
+In `http.go`, add:
+
+```go
+func noAuthIndexHandler(w http.ResponseWriter, req *http.Request) error {
+	var u User
+	if u.newFromRequest(req) == nil {
+		return Error{Code: http.StatusBadRequest, Message: "could not determine client IP"}
+	}
+	u.whitelist()
+
+	var data = struct {
+		Name      string
+		IPAddress string
+	}{
+		Name:      u.name,
+		IPAddress: u.ip,
+	}
+	return noAuthTempl.Execute(w, &data)
+}
+
+func (a *Authentication) initNoAuth() {
+	http.Handle("/live", handle(livenessHandler))
+	http.Handle("/ready", handle(readinessHandler))
+	http.Handle("/", handle(noAuthIndexHandler))
+	log.Fatal(http.ListenAndServe(":8090", nil))
+}
+```
+
+- [ ] **Step 5: Wire the switch case in `Authentication.init`**
+
+In `http.go`, change the `switch` in `init` (~L129) to:
+
+```go
+	switch strings.ToLower(a.Type) {
+	case "azure":
+		a.initAzure()
+	case "none", "disabled":
+		a.initNoAuth()
+	default:
+		log.Fatalln("http.init(): unsupported authentication type '" + a.Type + "'")
+	}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `go test -run TestNoAuthIndexHandler -v .`
+Expected: PASS (this test starts a throwaway Redis container via `dockertest`, so it takes longer than the pure-unit tests — Docker must be running).
+
+- [ ] **Step 7: Confirm the existing OAuth handler tests still pass**
+
+Run: `go test -run 'TestIndexHandler|TestIndexHandlerWithToken|TestServeHTTP|TestLivenessHandler|TestReadinessHandler' -v .`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add http.go http_test.go
+git commit -m "feat: add no-auth index handler + auth.type none init path"
+```
+
+---
+
+### Task 5: Document `auth.type: none` in the README
+
+**Files:**
+- Modify: `README.md` (the `auth` config-table row, ~L65; new subsection before `### UniFi`, ~L89)
+
+- [ ] **Step 1: Update the `auth` row in the config table**
+
+In `README.md`, replace the existing `auth` table row (~L65):
+
+```
+| `auth`         | AzureAD tenant/client credentials (`type: azure`).                 |
+```
+
+with:
+
+```
+| `auth`         | Authentication mode: `type: azure` (AzureAD OAuth) or `type: none` (disable in-app auth — see [Disabling auth](#disabling-auth-reverse-proxy-sso)). |
+```
+
+- [ ] **Step 2: Add the "Disabling auth" subsection**
+
+In `README.md`, insert this new subsection immediately before `### UniFi` (~L89):
+
+````markdown
+### Disabling auth (reverse-proxy SSO)
+
+If you run ip-whitelister behind an SSO reverse proxy (e.g. Cloudflare Access,
+Authelia, oauth2-proxy) you can disable the built-in AzureAD login and let the
+proxy handle authentication:
+
+```yaml
+auth:
+  type: none   # alias: disabled
+  # header: Cf-Access-Authenticated-User-Email   # trusted identity header (default shown)
+```
+
+In this mode any request to `/` immediately whitelists the caller's IP and shows
+a confirmation page — there is no OAuth redirect or callback. The whitelist
+entry is keyed on the identity the proxy supplies in the configured `header`
+(default `Cf-Access-Authenticated-User-Email`); if that header is absent the
+entry is keyed on the client IP instead.
+
+Because AzureAD group membership is unavailable without OAuth, **group-scoped
+resources are skipped** in this mode — only resources without a `group:` filter
+are whitelisted. `tenant_id`, `client_id` and `client_secret` are ignored and
+can be omitted.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document auth.type none (reverse-proxy SSO)"
+```
+
+---
+
+### Task 6: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `go test ./...`
+Expected: PASS (this includes the Docker-backed Redis suite, ~60s).
+
+- [ ] **Step 2: Run the race detector**
+
+Run: `go test -race ./...`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 3: Vet and build**
+
+Run: `go vet ./... && go build ./...`
+Expected: no output (success).
+
+- [ ] **Step 4: Manual smoke check (optional)**
+
+Confirm the new mode is reachable by grepping the wired case:
+
+Run: `grep -n '"none", "disabled"' http.go`
+Expected: one match in the `init` switch.
+
+---
+
+## Notes for the implementer
+
+- The package is a flat `package main`; there are no subpackages. Run tests from the repo root.
+- Do NOT use `stubRedis()` for the handler test. `getWhitelist()` calls `log.Fatal` on any Redis error, and `stubRedis()`'s fake conn returns errors — so it would exit the test process. The handler exercises the real whitelist path, so it uses `CreateTestRedis` (Docker), mirroring `TestUserWhitelist`. `stubRedis()` only works for the UniFi tests because they set `w.List` manually and never call `getWhitelist`.
+- Global test state: `c`, `r`, `u`, `w`, `a` are package-level singletons shared across tests. Always restore `c.Auth.Header` with a `defer` (as the tests above do) so you don't leak state into other tests.
+- Do not touch the sample `config/config.yaml` — it stays on `type: azure`; no-auth is README-documented only (per the spec).

--- a/docs/superpowers/plans/2026-07-02-disable-auth-none.md
+++ b/docs/superpowers/plans/2026-07-02-disable-auth-none.md
@@ -612,6 +612,19 @@ Expected: one match in the `init` switch.
 
 ---
 
+### Task 7: Configurable client-IP header + review polish
+
+**Added after the final code review.** In no-auth mode the client IP must come from a trusted header the *proxy* sets — `X-Azure-Clientip` is only trustworthy behind Azure Front Door. Cloudflare puts the real client IP in `Cf-Connecting-Ip`, and leaving `X-Azure-Clientip` as the source (a) breaks IP capture behind Cloudflare and (b) lets an authenticated user spoof `X-Azure-Clientip` to whitelist an arbitrary IP. Fix: a configurable `ip_header`, defaulting to `Cf-Connecting-Ip` in no-auth mode, read in preference to `X-Azure-Clientip`. Azure mode is unchanged (empty `ip_header` → `X-Azure-Clientip`). Also folds in the review's cosmetic items.
+
+**Files:** `http.go` (struct + receiver + log msg), `config.go` (`applyAuthDefaults`), `user.go` (`finishUser`), `config_test.go`, `user_test.go`, `http_test.go`, `README.md`.
+
+- Add `IPHeader string \`yaml:"ip_header"\`` to `Authentication` (after `Header`).
+- `applyAuthDefaults`: for `none`/`disabled`, also default `IPHeader` to `Cf-Connecting-Ip` when empty.
+- `finishUser`: read the IP from `c.Auth.IPHeader` (fallback to `X-Azure-Clientip` when empty), then `RemoteAddr`.
+- Cosmetic: `initNoAuth` receiver → `func (*Authentication)`; `start()` log message `http.initAzure(): ...` → `http.start(): ...`; clarify the identity-fallback comment in `finishUser` (OAuth path always supplies identity).
+- Tests: extend `TestApplyAuthDefaults` for `ip_header`; update `TestUserNewFromRequest` + `TestNoAuthIndexHandler` to feed the IP via `Cf-Connecting-Ip` and set/reset `c.Auth.IPHeader`; make `TestUserNew` self-contained with `c.Auth.IPHeader = ""`.
+- README: document `ip_header` (default `Cf-Connecting-Ip`) and warn the proxy MUST set it to the real client IP and strip any client-supplied value.
+
 ## Notes for the implementer
 
 - The package is a flat `package main`; there are no subpackages. Run tests from the repo root.

--- a/docs/superpowers/specs/2026-07-02-disable-auth-none-provider-design.md
+++ b/docs/superpowers/specs/2026-07-02-disable-auth-none-provider-design.md
@@ -1,0 +1,178 @@
+# Disable auth (`auth.type: none`) — design
+
+**Date:** 2026-07-02
+**Status:** Approved (design)
+**Author:** Alec Pinson
+
+## Summary
+
+Add a no-auth authentication mode (`auth.type: none`, alias `disabled`) so the
+app can run behind an external SSO reverse proxy (e.g. Cloudflare Access)
+instead of doing its own AzureAD OAuth login. In this mode the app trusts that
+the upstream proxy has already authenticated the request. On any request to `/`
+it immediately whitelists the requester's public IP and shows a confirmation
+page — no OAuth redirect, no callback, no Microsoft Graph calls.
+
+The change is contained and mostly additive: the auth type is already dispatched
+through a `switch` on `auth.type` (`http.go`), and the whitelisting mechanism
+already derives the client IP from request headers, not from OAuth.
+
+## Motivation
+
+Personal need: run `ip-whitelister` with SSO provided by Cloudflare Access in
+front of it, rather than configuring an AzureAD app registration for OAuth.
+`auth.type` is currently effectively required to be `azure` — any other value
+hits the `default` branch and `log.Fatalln`s.
+
+## Background: what OAuth is coupled to today
+
+Three places depend on Azure OAuth:
+
+1. `Authentication.initAzure()` (`http.go`) — builds `oauthConfig`, **and**
+   registers the HTTP handlers (`/live`, `/ready`, `/callback`, `/`) and starts
+   the `:8090` listener.
+2. `IndexHandler` (`http.go`) — redirects unauthenticated users to the Azure
+   auth URL; the rendered page's JS uses the OAuth token to call Graph API for
+   the display name.
+3. `User.new(client, req)` (`user.go`) — uses the **OAuth client** to call Graph
+   API for `displayName`, `employeeId`, and **group memberships**.
+
+The client IP itself comes from `X-Azure-Clientip` / `RemoteAddr`
+(`user.go`), independent of OAuth, so the actual whitelisting needs no auth.
+
+The one capability lost without OAuth is **group-based whitelisting**
+(`User.groups`), because groups are sourced from AzureAD.
+
+## Key insight: group filtering already handles no-auth correctly
+
+`hasGroup(resourceGroups, userGroups)` (`functions.go`):
+
+```go
+func hasGroup(resourceGroups []string, userGroups []string) bool {
+	if resourceGroups == nil {
+		return true            // ungrouped resource → whitelist everyone
+	}
+	for _, rg := range resourceGroups {
+		for _, ug := range userGroups {
+			if rg == ug {
+				return true
+			}
+		}
+	}
+	return false               // grouped resource, no match → skip
+}
+```
+
+If a no-auth user has `groups == nil`:
+- **Ungrouped resources** (`Group == nil`) → whitelisted (correct).
+- **Group-scoped resources** (`Group != nil`) → skipped, since an empty user
+  group set never matches (correct — "skip group-scoped resources" per the
+  design decision).
+
+So the sync path needs **no changes**. Giving no-auth users empty groups
+produces the desired behaviour for free.
+
+## Design decisions
+
+- **Identity key:** configurable trusted header, defaulting to
+  `Cf-Access-Authenticated-User-Email`. This works with any reverse-proxy SSO,
+  not just Cloudflare. If the header is absent/empty on a request, fall back to
+  keying the whitelist entry on the client IP.
+- **Groups:** in no-auth mode, group-scoped resources are skipped (a whitelisted
+  IP only reaches ungrouped resources). Achieved by empty groups + existing
+  `hasGroup`.
+
+## Components / changes
+
+### 1. Config (`config.go`, `http.go`)
+
+- Add `Header string \`yaml:"header"\`` to the `Authentication` struct.
+- In `config.load`, when `auth.type` is `none`/`disabled` and `header` is blank,
+  default it to `Cf-Access-Authenticated-User-Email`.
+
+### 2. Auth init (`http.go`)
+
+- Add `case "none", "disabled":` to the `Authentication.init` switch → call a
+  new `initNoAuth()`.
+- `initNoAuth()` mirrors `initAzure()` minus OAuth: registers `/live`, `/ready`,
+  and `/` → `noAuthIndexHandler` (no `/callback`, no `oauthConfig`, no session
+  store), then `http.ListenAndServe(":8090", nil)`. Startup on `:8080` via the
+  existing `start()` is unchanged.
+
+### 3. Request handling (`http.go`)
+
+- New `noAuthIndexHandler(w, req)`: builds a `User` from the request alone
+  (`User.newFromRequest`), whitelists it (`u.whitelist()`), and renders a small
+  confirmation page ("Your IP `x.x.x.x` has been whitelisted", plus the identity
+  string when present). No redirect, no token, no Graph API JS. A dedicated,
+  minimal template is used rather than reusing the OAuth-token-driven
+  `indexTempl`.
+
+### 4. User construction (`user.go`)
+
+- Extract the shared tail of `User.new` (IP detection from
+  `X-Azure-Clientip`/`RemoteAddr`, the `::1` local-testing override, `cidr`
+  computation via `addNetmask`, and the key regex) into a helper method so both
+  constructors share it.
+- New `User.newFromRequest(req)` (no `*http.Client`):
+  - identity = value of the configured header if present; else fall back to the
+    client IP.
+  - `groups = nil`.
+  - key derived from the identity via the same regex normalisation as `new`.
+  - reuse the shared helper for IP / cidr / key.
+- `User.new` keeps calling Graph API and reuses the same shared helper.
+
+### 5. Sync path — unchanged
+
+Empty `groups` + existing `hasGroup` gives "skip group-scoped resources". The
+`updateResources` guard keys off `c.Auth.TenantId` (the login tenant), which is
+empty in no-auth mode, so resource sync proceeds normally.
+
+## Data flow (no-auth mode)
+
+1. Cloudflare Access (or another proxy) authenticates the user and forwards the
+   request with the trusted identity header set.
+2. User hits `/` → `noAuthIndexHandler`.
+3. `User.newFromRequest(req)`: identity from header (or IP fallback), IP from
+   request headers, `groups = nil`, key derived.
+4. `u.whitelist()` → `Whitelist.add()`: stores user→CIDR (+ empty groups) in
+   Redis with TTL, fires `updateResources()`.
+5. Resources sync: ungrouped resources get the IP; group-scoped resources skip
+   it.
+6. Confirmation page renders.
+7. Expiry unchanged: hourly `Whitelist.ttl()` re-push + Redis TTL.
+
+## Error handling
+
+- Missing identity header → fall back to IP-keyed entry (no error).
+- IP detection unchanged from `User.new` (logs on `RemoteAddr` parse failure).
+- Same `Whitelist.add` / Redis error paths as the existing flow.
+
+## Testing
+
+- `User.newFromRequest` (no Redis): header present → key from header; header
+  absent → key from IP; IP detection precedence (`X-Azure-Clientip` vs
+  `RemoteAddr`); `groups == nil`.
+- `noAuthIndexHandler` via `httptest` + the existing `stubRedis` fake redis
+  connection: a request whitelists and renders the confirmation page.
+- Assert an empty-group user is skipped for a group-scoped resource (verify
+  existing coverage; add if missing).
+- Config: `auth.type: none` loads and defaults `header` to
+  `Cf-Access-Authenticated-User-Email`.
+
+## Out of scope
+
+- Verifying the Cloudflare Access JWT (`Cf-Access-Jwt-Assertion`) signature. The
+  app trusts the proxy; JWT validation can be a later hardening step.
+- Any change to Azure OAuth behaviour or the Azure resource providers.
+- Restoring group-based whitelisting in no-auth mode (groups require AzureAD).
+
+## Files touched
+
+- `http.go` — new `case`, `initNoAuth`, `noAuthIndexHandler`, confirmation
+  template; `Authentication.Header` field.
+- `user.go` — shared IP/key helper, `newFromRequest`.
+- `config.go` — default header when `type: none`.
+- README — document `auth.type: none` + `header`. The sample
+  `config/config.yaml` stays on `azure`; no-auth is README-documented only.
+- Tests as above.

--- a/functions_test.go
+++ b/functions_test.go
@@ -64,6 +64,8 @@ func TestHasGroup(t *testing.T) {
 		{[]string{"group5"}, []string{"group5", "group10"}, true},
 		{[]string{"group1", "group2"}, []string{"group6", "group2"}, true},
 		{[]string{"group1"}, []string{"group9", "group10", "group11"}, false},
+		// a no-auth user has no groups -> group-scoped resources are skipped
+		{[]string{"group1"}, nil, false},
 		{[]string{"group1", "group2", "group3", "group4"}, []string{"group5"}, false},
 		// a resource with no group restriction (nil) is open to everyone
 		{nil, []string{"group1"}, true},

--- a/http.go
+++ b/http.go
@@ -72,6 +72,26 @@ var indexTempl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 </html>
 `))
 
+var noAuthTempl = template.Must(template.New("").Parse(`<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dynamic IP Whitelist</title>
+
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  </head>
+  <body class="container-fluid">
+    <div class="row">
+      <div class="col-xs-4 col-xs-offset-4">
+        <h1>Dynamic IP Whitelist</h1>
+        Welcome{{with .Name}} {{.}}{{end}}, your IP ({{.IPAddress}}) has been whitelisted.
+        <br>
+        <i>Note: It can take a few minutes for your whitelisting to become active. Please note that IPv6 cannot be whitelisted on all resources.</i>
+      </div>
+    </div>
+  </body>
+</html>
+`))
+
 func (h handle) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -130,6 +150,8 @@ func (*Authentication) init(a Authentication) {
 	switch strings.ToLower(a.Type) {
 	case "azure":
 		a.initAzure()
+	case "none", "disabled":
+		a.initNoAuth()
 	default:
 		log.Fatalln("http.init(): unsupported authentication type '" + a.Type + "'")
 	}
@@ -158,6 +180,30 @@ func (a *Authentication) initAzure() {
 	http.Handle("/ready", handle(readinessHandler))
 	http.Handle("/callback", handle(callbackHandler))
 	http.Handle("/", handle(IndexHandler))
+	log.Fatal(http.ListenAndServe(":8090", nil))
+}
+
+func noAuthIndexHandler(w http.ResponseWriter, req *http.Request) error {
+	var u User
+	if u.newFromRequest(req) == nil {
+		return Error{Code: http.StatusBadRequest, Message: "could not determine client IP"}
+	}
+	u.whitelist()
+
+	var data = struct {
+		Name      string
+		IPAddress string
+	}{
+		Name:      u.name,
+		IPAddress: u.ip,
+	}
+	return noAuthTempl.Execute(w, &data)
+}
+
+func (a *Authentication) initNoAuth() {
+	http.Handle("/live", handle(livenessHandler))
+	http.Handle("/ready", handle(readinessHandler))
+	http.Handle("/", handle(noAuthIndexHandler))
 	log.Fatal(http.ListenAndServe(":8090", nil))
 }
 

--- a/http.go
+++ b/http.go
@@ -134,6 +134,7 @@ var (
 type Authentication struct {
 	Type         string `yaml:"type"`
 	Header       string `yaml:"header"`
+	IPHeader     string `yaml:"ip_header"`
 	TenantId     string `yaml:"tenant_id"`
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
@@ -200,7 +201,7 @@ func noAuthIndexHandler(w http.ResponseWriter, req *http.Request) error {
 	return noAuthTempl.Execute(w, &data)
 }
 
-func (a *Authentication) initNoAuth() {
+func (*Authentication) initNoAuth() {
 	http.Handle("/live", handle(livenessHandler))
 	http.Handle("/ready", handle(readinessHandler))
 	http.Handle("/", handle(noAuthIndexHandler))
@@ -209,7 +210,7 @@ func (a *Authentication) initNoAuth() {
 
 func (a *Authentication) start() {
 	httpReady = true
-	log.Print("http.initAzure(): ip whitelister started")
+	log.Print("http.start(): ip whitelister started")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 

--- a/http.go
+++ b/http.go
@@ -113,6 +113,7 @@ var (
 
 type Authentication struct {
 	Type         string `yaml:"type"`
+	Header       string `yaml:"header"`
 	TenantId     string `yaml:"tenant_id"`
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`

--- a/http_test.go
+++ b/http_test.go
@@ -214,3 +214,48 @@ func TestIndexHandlerWithToken(t *testing.T) {
 		t.Errorf("IndexHandler() with token should not render the redirect branch:\n%s", body)
 	}
 }
+
+func TestNoAuthIndexHandler(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	// config is never loaded in tests; give redis keys a real TTL and set the
+	// trusted header the no-auth path reads.
+	c.TTL = 24
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	defer func() { c.Auth.Header = "" }()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "alice@example.com")
+	req.Header.Set("X-Azure-Clientip", "203.0.113.7")
+	rr := httptest.NewRecorder()
+
+	if err := noAuthIndexHandler(rr, req); err != nil {
+		t.Fatalf("noAuthIndexHandler() unexpected error: %v", err)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "203.0.113.7") {
+		t.Errorf("body missing whitelisted IP:\n%s", body)
+	}
+	if !strings.Contains(body, "alice@example.com") {
+		t.Errorf("body missing identity:\n%s", body)
+	}
+	if !strings.Contains(body, "has been whitelisted") {
+		t.Errorf("body missing confirmation text:\n%s", body)
+	}
+	if strings.Contains(body, "Whitelisting your IP") {
+		t.Errorf("body unexpectedly rendered the OAuth redirect branch:\n%s", body)
+	}
+
+	if got := r.getWhitelist()["aliceexamplecom"]; got != "203.0.113.7/32" {
+		t.Errorf("redis whitelist entry = %q, want %q", got, "203.0.113.7/32")
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -231,10 +231,12 @@ func TestNoAuthIndexHandler(t *testing.T) {
 	c.TTL = 24
 	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
 	defer func() { c.Auth.Header = "" }()
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	defer func() { c.Auth.IPHeader = "" }()
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Cf-Access-Authenticated-User-Email", "alice@example.com")
-	req.Header.Set("X-Azure-Clientip", "203.0.113.7")
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
 	rr := httptest.NewRecorder()
 
 	if err := noAuthIndexHandler(rr, req); err != nil {

--- a/user.go
+++ b/user.go
@@ -86,36 +86,54 @@ func (u *User) new(client *http.Client, req *http.Request) *User {
 		log.Printf("user.new(): %v groups: %v", u.name, u.groups)
 	}
 
-	// Create our 'key' by removing spaces, converting to lower and removing all special characters
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		log.Fatal("user.new():", err)
-	}
-	u.key = strings.ToLower(reg.ReplaceAllString(u.name+u.employeeId, ""))
-
-	// get ip
-	u.ip = req.Header.Get("X-Azure-Clientip")
-	if u.ip == "" {
-		u.ip, _, err = net.SplitHostPort(req.RemoteAddr)
-		if err != nil {
-			log.Printf("user.new(): %q is not IP:port\n", req.RemoteAddr)
-		}
-	}
-
-	// annoying when testing locally, make up an ip :)
-	if u.ip == "::1" {
-		u.ip = "80.18.81.18"
-		// u.ip = "1a00:12a1:1234:a123:a12a:12a1:1a12:1234" // ipv6 testing
-	}
-
-	u.cidr, err = addNetmask(u.ip)
-	if err != nil {
+	// derive key, client IP, and cidr (shared with the no-auth path)
+	if err := u.finishUser(u.name+u.employeeId, req); err != nil {
 		log.Fatal("user.new(): ", err)
 	}
 
 	log.Println("user.new(): authentication successful - " + u.name + " (" + u.employeeId + ") - " + u.ip)
 
 	return u
+}
+
+// finishUser fills in the request-derived fields shared by both the OAuth and
+// no-auth constructors: the client IP (with a loopback override for local
+// testing), its cidr, and the whitelist key derived from identity. When
+// identity is empty the key falls back to the client IP.
+func (u *User) finishUser(identity string, req *http.Request) error {
+	// get ip
+	u.ip = req.Header.Get("X-Azure-Clientip")
+	if u.ip == "" {
+		var err error
+		u.ip, _, err = net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
+			log.Printf("user.finishUser(): %q is not IP:port\n", req.RemoteAddr)
+		}
+	}
+
+	// annoying when testing locally, make up an ip :)
+	if u.ip == "::1" {
+		u.ip = "80.18.81.18"
+	}
+
+	cidr, err := addNetmask(u.ip)
+	if err != nil {
+		return err
+	}
+	u.cidr = cidr
+
+	// Create our 'key' by removing spaces, lower-casing and stripping special
+	// characters. Fall back to the IP when there is no identity (no-auth mode).
+	if identity == "" {
+		identity = u.ip
+	}
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		return err
+	}
+	u.key = strings.ToLower(reg.ReplaceAllString(identity, ""))
+
+	return nil
 }
 
 func (u *User) whitelist() {

--- a/user.go
+++ b/user.go
@@ -136,6 +136,28 @@ func (u *User) finishUser(identity string, req *http.Request) error {
 	return nil
 }
 
+// newFromRequest builds a User without OAuth, for auth.type: none. Identity
+// comes from the configured trusted header (set by an upstream SSO proxy such
+// as Cloudflare Access). Groups are unavailable, so u.groups stays nil and the
+// existing hasGroup logic skips group-scoped resources.
+func (u *User) newFromRequest(req *http.Request) *User {
+	var identity string
+	if c.Auth.Header != "" {
+		identity = req.Header.Get(c.Auth.Header)
+	}
+	if identity != "" {
+		u.name = identity
+	}
+
+	if err := u.finishUser(identity, req); err != nil {
+		log.Printf("user.newFromRequest(): %v", err)
+		return nil
+	}
+
+	log.Println("user.newFromRequest(): request accepted - " + u.name + " - " + u.ip)
+	return u
+}
+
 func (u *User) whitelist() {
 	s := w.add(u)
 	if s {

--- a/user.go
+++ b/user.go
@@ -101,8 +101,14 @@ func (u *User) new(client *http.Client, req *http.Request) *User {
 // testing), its cidr, and the whitelist key derived from identity. When
 // identity is empty the key falls back to the client IP.
 func (u *User) finishUser(identity string, req *http.Request) error {
-	// get ip
-	u.ip = req.Header.Get("X-Azure-Clientip")
+	// get ip from the configured trusted header. Azure Front Door sets
+	// X-Azure-Clientip (the default when ip_header is unset); no-auth mode uses
+	// ip_header (e.g. Cf-Connecting-Ip). Fall back to RemoteAddr when absent.
+	ipHeader := c.Auth.IPHeader
+	if ipHeader == "" {
+		ipHeader = "X-Azure-Clientip"
+	}
+	u.ip = req.Header.Get(ipHeader)
 	if u.ip == "" {
 		var err error
 		u.ip, _, err = net.SplitHostPort(req.RemoteAddr)
@@ -123,7 +129,8 @@ func (u *User) finishUser(identity string, req *http.Request) error {
 	u.cidr = cidr
 
 	// Create our 'key' by removing spaces, lower-casing and stripping special
-	// characters. Fall back to the IP when there is no identity (no-auth mode).
+	// characters. Fall back to the IP when there is no identity (no-auth mode);
+	// the OAuth path always supplies a non-empty identity.
 	if identity == "" {
 		identity = u.ip
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -47,6 +47,8 @@ func fakeGraphClient(me, memberOf fakeResponse) *http.Client {
 
 func TestUserNew(t *testing.T) {
 	c.Debug = false
+	c.Auth.IPHeader = "" // azure path reads X-Azure-Clientip
+	defer func() { c.Auth.IPHeader = "" }()
 
 	tests := []struct {
 		name         string
@@ -173,11 +175,13 @@ func TestUserNewFromRequest(t *testing.T) {
 	c.Debug = false
 	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
 	defer func() { c.Auth.Header = "" }()
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	defer func() { c.Auth.IPHeader = "" }()
 
 	tests := []struct {
 		name       string
 		header     string // Cf-Access-Authenticated-User-Email value ("" = not set)
-		clientIP   string // X-Azure-Clientip value ("" = not set)
+		clientIP   string // Cf-Connecting-Ip value ("" = not set)
 		remoteAddr string
 		wantName   string
 		wantKey    string
@@ -221,7 +225,7 @@ func TestUserNewFromRequest(t *testing.T) {
 			req := httptest.NewRequest("GET", "/", nil)
 			req.RemoteAddr = f.remoteAddr
 			if f.clientIP != "" {
-				req.Header.Set("X-Azure-Clientip", f.clientIP)
+				req.Header.Set("Cf-Connecting-Ip", f.clientIP)
 			}
 			if f.header != "" {
 				req.Header.Set("Cf-Access-Authenticated-User-Email", f.header)

--- a/user_test.go
+++ b/user_test.go
@@ -169,6 +169,87 @@ func TestUserWhitelist(t *testing.T) {
 	}
 }
 
+func TestUserNewFromRequest(t *testing.T) {
+	c.Debug = false
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	defer func() { c.Auth.Header = "" }()
+
+	tests := []struct {
+		name       string
+		header     string // Cf-Access-Authenticated-User-Email value ("" = not set)
+		clientIP   string // X-Azure-Clientip value ("" = not set)
+		remoteAddr string
+		wantName   string
+		wantKey    string
+		wantIP     string
+		wantCidr   string
+	}{
+		{
+			name:       "identity from trusted header",
+			header:     "alice@example.com",
+			clientIP:   "1.2.3.4",
+			remoteAddr: "10.0.0.1:5555",
+			wantName:   "alice@example.com",
+			wantKey:    "aliceexamplecom",
+			wantIP:     "1.2.3.4",
+			wantCidr:   "1.2.3.4/32",
+		},
+		{
+			name:       "no header falls back to keying on IP",
+			header:     "",
+			clientIP:   "",
+			remoteAddr: "8.8.8.8:1234",
+			wantName:   "",
+			wantKey:    "8888",
+			wantIP:     "8.8.8.8",
+			wantCidr:   "8.8.8.8/32",
+		},
+		{
+			name:       "loopback is rewritten for local testing",
+			header:     "",
+			clientIP:   "::1",
+			remoteAddr: "[::1]:8080",
+			wantName:   "",
+			wantKey:    "80188118",
+			wantIP:     "80.18.81.18",
+			wantCidr:   "80.18.81.18/32",
+		},
+	}
+
+	for _, f := range tests {
+		t.Run(f.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = f.remoteAddr
+			if f.clientIP != "" {
+				req.Header.Set("X-Azure-Clientip", f.clientIP)
+			}
+			if f.header != "" {
+				req.Header.Set("Cf-Access-Authenticated-User-Email", f.header)
+			}
+
+			var u User
+			if got := u.newFromRequest(req); got == nil {
+				t.Fatalf("newFromRequest() returned nil, want a populated user")
+			}
+			if u.name != f.wantName {
+				t.Errorf("name: got %q, want %q", u.name, f.wantName)
+			}
+			if u.key != f.wantKey {
+				t.Errorf("key: got %q, want %q", u.key, f.wantKey)
+			}
+			if u.ip != f.wantIP {
+				t.Errorf("ip: got %q, want %q", u.ip, f.wantIP)
+			}
+			if u.cidr != f.wantCidr {
+				t.Errorf("cidr: got %q, want %q", u.cidr, f.wantCidr)
+			}
+			if u.groups != nil {
+				t.Errorf("groups: got %v, want nil", u.groups)
+			}
+		})
+	}
+}
+
 func TestUserNewErrorStatus(t *testing.T) {
 	c.Debug = false
 


### PR DESCRIPTION
## Summary

Adds an `auth.type: none` (alias `disabled`) mode so ip-whitelister can run behind an external SSO reverse proxy (e.g. Cloudflare Access) instead of doing its own AzureAD OAuth login. On any request to `/` it whitelists the caller's IP directly from trusted proxy headers — no OAuth redirect, callback, or Microsoft Graph call.

Built on the existing `switch auth.type` seam; the `azure` path is unchanged.

## What changed

- **Config:** new `auth.header` (identity) and `auth.ip_header` (client IP) fields. In no-auth mode they default to `Cf-Access-Authenticated-User-Email` and `Cf-Connecting-Ip` respectively (`applyAuthDefaults`).
- **No-auth flow:** `initNoAuth` + `noAuthIndexHandler` + a confirmation template. Identity comes from the configured trusted header (falls back to keying on the client IP); `User.newFromRequest` builds the user without OAuth.
- **Refactor:** shared request-derived logic (IP/cidr/key) extracted from `User.new` into `User.finishUser` — no behaviour change to the OAuth path.
- **Groups:** no-auth users have no AzureAD groups, so group-scoped resources are skipped automatically via the existing `hasGroup` logic (added a test case to lock this in).
- **Security (from review):** the client IP is read from a configurable, proxy-set header rather than the spoofable hardcoded `X-Azure-Clientip`. Azure Front Door users set `ip_header: X-Azure-Clientip`.
- **Docs:** README "Disabling auth (reverse-proxy SSO)" section, including a warning that the proxy must set/strip `ip_header`.

Spec + plan under `docs/superpowers/`.

## Test plan

- [x] `go test ./...` — full suite green (incl. dockertest Redis)
- [x] `go test -race ./...` — no races
- [x] `go vet ./...` / `go build ./...` clean
- [x] New unit tests: `TestApplyAuthDefaults`, `TestUserNewFromRequest`, `TestNoAuthIndexHandler` (real-Redis whitelist assertion), `hasGroup` empty-group case
- [x] Manually verified end-to-end via `docker-compose.dev.yaml` + `config.dev`: request accepted → IP whitelisted → stored in Redis
- [x] Confirmed azure OAuth path unchanged (`TestUserNew` / `TestIndexHandler*` still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)