### PR TITLE
fix: reuse UniFi session to avoid double-login 403

### DIFF
--- a/unifi.go
+++ b/unifi.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -45,6 +46,14 @@ type unifiClient interface {
 type unifiApplicationClient struct {
 	cfg  UnifiConfiguration
 	http *http.Client
+
+	// mu serialises authenticated requests and guards csrf. The session is
+	// reused across update() calls: UniFi rate-limits back-to-back logins with a
+	// 403, so we log in once (lazily) and only re-authenticate when the session
+	// expires. Serialising also stops concurrent update()s rotating the token
+	// mid-flight.
+	mu   sync.Mutex
+	csrf string // cached CSRF token for the live session; "" means logged out
 }
 
 // newUnifiClient builds the real unifiClient implementation. TLS verification is
@@ -68,39 +77,73 @@ func (uc *unifiApplicationClient) base() string {
 	return strings.TrimRight(uc.cfg.Host, "/") + "/proxy/network/api/s/" + uc.cfg.Site + "/rest/firewallgroup"
 }
 
-// login authenticates against the gateway and returns the CSRF token. The token
-// is returned (not stored on the struct) so concurrent update() calls sharing
-// this client don't clobber each other's token — a data race that caused
-// intermittent 403s. The session cookie lives in the shared cookiejar, which is
-// safe for concurrent use.
-func (uc *unifiApplicationClient) login() (string, error) {
+// login authenticates against the gateway and caches the session's CSRF token.
+// The session cookie is stored in the client's cookiejar. Callers must hold uc.mu.
+func (uc *unifiApplicationClient) login() error {
 	body, _ := json.Marshal(map[string]string{"username": uc.cfg.Username, "password": uc.cfg.Password})
 	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(uc.cfg.Host, "/")+"/api/auth/login", bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := uc.http.Do(req)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unifi login failed: status %d", resp.StatusCode)
+		return fmt.Errorf("unifi login failed: status %d", resp.StatusCode)
 	}
-	return resp.Header.Get("X-CSRF-Token"), nil
+	uc.csrf = resp.Header.Get("X-CSRF-Token")
+	return nil
+}
+
+// authedDo performs an authenticated request against the gateway, reusing the
+// existing session so we don't trip UniFi's login rate limit (which 403s
+// back-to-back logins). It logs in lazily on first use, refreshes the rotating
+// CSRF token from each response, and re-authenticates once if the session has
+// expired (401) or the token is stale (403). uc.mu serialises requests so a
+// concurrent update() can't rotate the token out from under an in-flight call.
+func (uc *unifiApplicationClient) authedDo(method, url string, body []byte) (*http.Response, error) {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if uc.csrf == "" {
+			if err := uc.login(); err != nil {
+				return nil, err
+			}
+		}
+		req, err := http.NewRequest(method, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("X-CSRF-Token", uc.csrf)
+		resp, err := uc.http.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if t := resp.Header.Get("X-CSRF-Token"); t != "" {
+			uc.csrf = t
+		}
+		// Session expired or token stale: drop it and re-login on the retry.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			resp.Body.Close()
+			uc.csrf = ""
+			lastErr = fmt.Errorf("unifi %s: status %d", method, resp.StatusCode)
+			continue
+		}
+		return resp, nil
+	}
+	return nil, lastErr
 }
 
 func (uc *unifiApplicationClient) getFirewallGroup(name string) (unifiFirewallGroup, error) {
-	// GET only needs the session cookie from the jar, not the CSRF token.
-	if _, err := uc.login(); err != nil {
-		return unifiFirewallGroup{}, err
-	}
-	req, err := http.NewRequest(http.MethodGet, uc.base(), nil)
-	if err != nil {
-		return unifiFirewallGroup{}, err
-	}
-	resp, err := uc.http.Do(req)
+	resp, err := uc.authedDo(http.MethodGet, uc.base(), nil)
 	if err != nil {
 		return unifiFirewallGroup{}, err
 	}
@@ -123,18 +166,8 @@ func (uc *unifiApplicationClient) getFirewallGroup(name string) (unifiFirewallGr
 }
 
 func (uc *unifiApplicationClient) updateFirewallGroup(g unifiFirewallGroup) error {
-	csrf, err := uc.login()
-	if err != nil {
-		return err
-	}
 	body, _ := json.Marshal(g)
-	req, err := http.NewRequest(http.MethodPut, uc.base()+"/"+g.ID, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-CSRF-Token", csrf)
-	resp, err := uc.http.Do(req)
+	resp, err := uc.authedDo(http.MethodPut, uc.base()+"/"+g.ID, body)
 	if err != nil {
 		return err
 	}
@@ -177,6 +210,7 @@ func (nl *UnifiNetworkList) buildMembers(list map[string]string, getGroups func(
 	members := []string{}
 	seen := make(map[string]struct{})
 	add := func(ip string) {
+		ip = unifiMember(ip)
 		if _, ok := seen[ip]; ok {
 			return
 		}
@@ -200,6 +234,15 @@ func (nl *UnifiNetworkList) buildMembers(list map[string]string, getGroups func(
 		}
 	}
 	return members
+}
+
+// unifiMember formats an address for a UniFi firewall group. UniFi stores single
+// hosts as bare IPs — its UI rejects a /32 suffix ("enter single host addresses
+// without the subnet mask") — so we strip a /32 while leaving real subnets (e.g.
+// /24) untouched. Matching UniFi's stored form also keeps sameMembers() stable,
+// so an unchanged whitelist doesn't force a PUT on every reconcile.
+func unifiMember(ip string) string {
+	return strings.TrimSuffix(ip, "/32")
 }
 
 func (*UnifiNetworkList) new(nl UnifiNetworkList) {

--- a/unifi_test.go
+++ b/unifi_test.go
@@ -91,9 +91,9 @@ func TestBuildMembers(t *testing.T) {
 	got := nl.buildMembers(list, getGroups)
 
 	want := map[string]bool{
-		"1.1.1.1/32": true, // alice, group match
-		"8.8.8.8/32": true, // per-list static
-		"9.9.9.9/32": true, // global static
+		"1.1.1.1": true, // alice, group match (host -> bare)
+		"8.8.8.8": true, // per-list static
+		"9.9.9.9": true, // global static
 	}
 	if len(got) != len(want) {
 		t.Fatalf("buildMembers returned %v, want keys %v", got, want)
@@ -105,6 +105,31 @@ func TestBuildMembers(t *testing.T) {
 	}
 }
 
+// TestBuildMembersStripsHostMask asserts single hosts are emitted as bare IPs
+// (UniFi stores /32 hosts without the mask and rejects the /32 suffix in its UI),
+// while real subnets keep their mask.
+func TestBuildMembersStripsHostMask(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = []string{"9.9.9.9/32", "85.0.0.0/24"} // host + real subnet
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "l", Group: nil}
+	list := map[string]string{"alice": "1.1.1.1/32"}
+	got := nl.buildMembers(list, getGroups)
+	want := map[string]bool{
+		"1.1.1.1":     true, // dynamic host -> bare
+		"9.9.9.9":     true, // static host -> bare
+		"85.0.0.0/24": true, // real subnet -> unchanged
+	}
+	if len(got) != len(want) {
+		t.Fatalf("buildMembers = %v, want keys %v", got, want)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected member %q in %v (want bare hosts, subnets kept)", m, got)
+		}
+	}
+}
+
 func TestBuildMembersNilGroupIncludesEveryone(t *testing.T) {
 	c.Debug = false
 	c.IPWhiteList = nil
@@ -112,8 +137,8 @@ func TestBuildMembersNilGroupIncludesEveryone(t *testing.T) {
 	nl := UnifiNetworkList{Name: "open", Group: nil} // nil group -> hasGroup returns true
 	list := map[string]string{"alice": "1.1.1.1/32", "bad": "not-an-ip"}
 	got := nl.buildMembers(list, getGroups)
-	if len(got) != 1 || got[0] != "1.1.1.1/32" {
-		t.Errorf("buildMembers = %v, want [1.1.1.1/32] (invalid IP skipped)", got)
+	if len(got) != 1 || got[0] != "1.1.1.1" {
+		t.Errorf("buildMembers = %v, want [1.1.1.1] (host -> bare, invalid IP skipped)", got)
 	}
 }
 
@@ -135,8 +160,8 @@ func TestBuildMembersDeduplicates(t *testing.T) {
 	for _, m := range got {
 		seen[m]++
 	}
-	if seen["1.1.1.1/32"] != 1 || seen["5.5.5.5/32"] != 1 {
-		t.Errorf("expected each of 1.1.1.1/32 and 5.5.5.5/32 exactly once, got %v", got)
+	if seen["1.1.1.1"] != 1 || seen["5.5.5.5"] != 1 {
+		t.Errorf("expected each of 1.1.1.1 and 5.5.5.5 exactly once, got %v", got)
 	}
 }
 
@@ -163,7 +188,9 @@ func TestUpdateNoChange(t *testing.T) {
 	c.Debug = false
 	c.IPWhiteList = nil
 	w.List = map[string]string{"alice": "1.1.1.1/32"}
-	fake := &fakeUnifiClient{group: unifiFirewallGroup{ID: "abc", Name: "l", GroupType: "address-group", Members: []string{"1.1.1.1/32"}}}
+	// UniFi stores single hosts bare, so the existing group has no /32 — the built
+	// member (also bare) must match it, producing no change.
+	fake := &fakeUnifiClient{group: unifiFirewallGroup{ID: "abc", Name: "l", GroupType: "address-group", Members: []string{"1.1.1.1"}}}
 	nl := UnifiNetworkList{Name: "l", client: fake}
 	// getGroups via Redis is bypassed: buildMembers uses r.getGroups in update(),
 	// so stub the whitelist to a single entry whose group check passes (nil Group).
@@ -180,7 +207,7 @@ func TestUpdateChange(t *testing.T) {
 	c.Debug = false
 	c.IPWhiteList = nil
 	w.List = map[string]string{"alice": "2.2.2.2/32"}
-	fake := &fakeUnifiClient{group: unifiFirewallGroup{ID: "abc", Name: "l", GroupType: "address-group", Members: []string{"1.1.1.1/32"}}}
+	fake := &fakeUnifiClient{group: unifiFirewallGroup{ID: "abc", Name: "l", GroupType: "address-group", Members: []string{"1.1.1.1"}}}
 	nl := UnifiNetworkList{Name: "l", client: fake}
 	if ret := nl.update(); ret != 0 {
 		t.Fatalf("update() = %d, want 0", ret)
@@ -188,8 +215,8 @@ func TestUpdateChange(t *testing.T) {
 	if fake.updateCalls != 1 {
 		t.Fatalf("updateFirewallGroup called %d times, want 1", fake.updateCalls)
 	}
-	if fake.updated.ID != "abc" || len(fake.updated.Members) != 1 || fake.updated.Members[0] != "2.2.2.2/32" {
-		t.Errorf("PUT body = %+v, want id=abc members=[2.2.2.2/32]", *fake.updated)
+	if fake.updated.ID != "abc" || len(fake.updated.Members) != 1 || fake.updated.Members[0] != "2.2.2.2" {
+		t.Errorf("PUT body = %+v, want id=abc members=[2.2.2.2]", *fake.updated)
 	}
 }
 
@@ -216,28 +243,34 @@ func TestUpdatePutError(t *testing.T) {
 	}
 }
 
-func TestUnifiApplicationClientGetAndUpdate(t *testing.T) {
+// TestUnifiApplicationClientReusesSession is the regression test for the
+// double-login 403: two full get+update cycles must share ONE login, because
+// UniFi rate-limits back-to-back logins. It also checks the rotating CSRF token
+// from the GET response is carried into the PUT.
+func TestUnifiApplicationClientReusesSession(t *testing.T) {
 	var loginHits, putHits int
 	var putBody unifiFirewallGroup
+	var putCSRF string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.URL.Path == "/api/auth/login":
 			loginHits++
-			rw.Header().Set("X-CSRF-Token", "csrf123")
+			rw.Header().Set("X-CSRF-Token", "csrf-login")
 			rw.WriteHeader(http.StatusOK)
 		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/rest/firewallgroup"):
+			// UniFi rotates the CSRF token per response; the freshest one on the
+			// GET response must be used for the subsequent PUT.
+			rw.Header().Set("X-CSRF-Token", "csrf-get")
 			_ = json.NewEncoder(rw).Encode(map[string]interface{}{
 				"data": []unifiFirewallGroup{{
 					ID: "abc", Name: "ip-whitelister", GroupType: "address-group",
-					Members: []string{"1.1.1.1/32"},
+					Members: []string{"1.1.1.1"},
 				}},
 			})
 		case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/rest/firewallgroup/abc"):
 			putHits++
-			if req.Header.Get("X-CSRF-Token") != "csrf123" {
-				t.Errorf("PUT missing X-CSRF-Token header")
-			}
+			putCSRF = req.Header.Get("X-CSRF-Token")
 			_ = json.NewDecoder(req.Body).Decode(&putBody)
 			_ = json.NewEncoder(rw).Encode(map[string]interface{}{"data": []unifiFirewallGroup{}})
 		default:
@@ -248,26 +281,69 @@ func TestUnifiApplicationClientGetAndUpdate(t *testing.T) {
 
 	client := newUnifiClient(UnifiConfiguration{Host: srv.URL, Site: "default", Username: "u", Password: "p"})
 
-	g, err := client.getFirewallGroup("ip-whitelister")
-	if err != nil {
-		t.Fatalf("getFirewallGroup error: %v", err)
-	}
-	if g.ID != "abc" || len(g.Members) != 1 || g.Members[0] != "1.1.1.1/32" {
-		t.Fatalf("getFirewallGroup = %+v, want id=abc members=[1.1.1.1/32]", g)
+	// Two independent update cycles, as separate whitelist events would trigger.
+	for i := 0; i < 2; i++ {
+		g, err := client.getFirewallGroup("ip-whitelister")
+		if err != nil {
+			t.Fatalf("cycle %d getFirewallGroup error: %v", i, err)
+		}
+		if g.ID != "abc" || len(g.Members) != 1 || g.Members[0] != "1.1.1.1" {
+			t.Fatalf("cycle %d getFirewallGroup = %+v, want id=abc members=[1.1.1.1]", i, g)
+		}
+		g.Members = []string{"2.2.2.2"}
+		if err := client.updateFirewallGroup(g); err != nil {
+			t.Fatalf("cycle %d updateFirewallGroup error: %v", i, err)
+		}
 	}
 
-	g.Members = []string{"2.2.2.2/32"}
-	if err := client.updateFirewallGroup(g); err != nil {
-		t.Fatalf("updateFirewallGroup error: %v", err)
+	if loginHits != 1 {
+		t.Errorf("login hits = %d, want 1 (session reused across both cycles; a 2nd login is the 403 bug)", loginHits)
 	}
-	if putHits != 1 {
-		t.Errorf("PUT hits = %d, want 1", putHits)
+	if putHits != 2 {
+		t.Errorf("PUT hits = %d, want 2", putHits)
 	}
-	if putBody.ID != "abc" || len(putBody.Members) != 1 || putBody.Members[0] != "2.2.2.2/32" {
-		t.Errorf("PUT body = %+v, want id=abc members=[2.2.2.2/32]", putBody)
+	if putCSRF != "csrf-get" {
+		t.Errorf("PUT X-CSRF-Token = %q, want %q (freshest token from GET response)", putCSRF, "csrf-get")
 	}
-	if loginHits < 1 {
-		t.Errorf("expected at least one login, got %d", loginHits)
+	if putBody.ID != "abc" || len(putBody.Members) != 1 || putBody.Members[0] != "2.2.2.2" {
+		t.Errorf("PUT body = %+v, want id=abc members=[2.2.2.2]", putBody)
+	}
+}
+
+// TestUnifiApplicationClientReloginsOnSessionExpiry covers session expiry: when a
+// request comes back 401, the client drops the stale session, logs in again, and
+// retries — so a long-lived process recovers without a restart.
+func TestUnifiApplicationClientReloginsOnSessionExpiry(t *testing.T) {
+	var loginHits, getHits int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.URL.Path == "/api/auth/login":
+			loginHits++
+			rw.Header().Set("X-CSRF-Token", "csrf-login")
+			rw.WriteHeader(http.StatusOK)
+		default: // GET firewallgroup: first call 401 (expired), then succeeds
+			getHits++
+			if getHits == 1 {
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(rw).Encode(map[string]interface{}{
+				"data": []unifiFirewallGroup{{ID: "abc", Name: "l", Members: []string{}}},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := newUnifiClient(UnifiConfiguration{Host: srv.URL, Site: "default"})
+	if _, err := client.getFirewallGroup("l"); err != nil {
+		t.Fatalf("getFirewallGroup error: %v", err)
+	}
+	if loginHits != 2 {
+		t.Errorf("login hits = %d, want 2 (initial login + re-login after 401)", loginHits)
+	}
+	if getHits != 2 {
+		t.Errorf("GET hits = %d, want 2 (retried after re-login)", getHits)
 	}
 }
 


### PR DESCRIPTION
## Problem

`UnifiNetworkList.update()` authenticated on **every** call, and UniFi rate-limits back-to-back logins with a **403**. The startup sync (first login) succeeded, but the next `update()` — triggered by a whitelist event — logged in again and got throttled, so the Network List went stale.

Observed live (logins ~12–25s apart both failed):

```
unifi.UnifiNetworkList.update(): updating 'ip-whitelister'
unifi.UnifiNetworkList.update(): updated 'ip-whitelister'   # startup: 1st login, OK
...
unifi.UnifiNetworkList.update(): updating 'ip-whitelister'
unifi.UnifiNetworkList.update():unifi login failed: status 403   # visit: 2nd login, throttled
```

## Fix

**Session reuse.** The client now logs in **once (lazily)**, caches the session cookie + rotating CSRF token, and reuses it across updates via a new `authedDo` helper. It refreshes the CSRF token from each response and **re-authenticates once on 401/403**, so a long-running process recovers from an expired session without a restart. A `sync.Mutex` serialises requests and guards the token, keeping concurrent `update()`s (whitelist adds + hourly TTL) race-free.

**Member format.** Single hosts are now emitted as **bare IPs** (`unifiMember` strips `/32`) — UniFi rejects the `/32` suffix on single hosts and stores them bare — while real subnets (e.g. `/24`) keep their mask. This lets the whitelisted host actually persist, and keeps `sameMembers()` stable so an unchanged whitelist no longer forces a PUT every reconcile.

## Tests

- `TestUnifiApplicationClientReusesSession` — two update cycles share **one** login (verified it fails against the old login-per-request behavior).
- `TestUnifiApplicationClientReloginsOnSessionExpiry` — 401 → re-login → retry.
- Updated `buildMembers` / `update` tests to the bare-host format.
- Full suite green, including `go test -race` and the docker-backed Redis suite.

Validated against a live UniFi gateway: whitelist event now syncs (no 403) and the host lands in the Network List.

🤖 Generated with [Claude Code](https://claude.com/claude-code)