### PR TITLE
feat: add ip_version resource field (IPv6 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ Key top-level options:
 | `unifi`        | UniFi gateway connection + credentials (see [UniFi](#unifi)).       |
 | `resources`    | List of cloud resources to whitelist against (see example config). |
 | `ip_whitelist` | Static, always-applied IPs — for non-human/proxy addresses only.   |
+| `ip_version`   | Per-resource address family: `ipv4` (default), `ipv6`, or `both`. |
+
+### Address families (`ip_version`)
+
+Each entry in `resources` takes an optional `ip_version`:
+
+| Value  | Effect                                              |
+| ------ | --------------------------------------------------- |
+| `ipv4` | Only IPv4 addresses are whitelisted. **Default.**   |
+| `ipv6` | Only IPv6 addresses are whitelisted.                |
+| `both` | Both families are whitelisted.                      |
+
+A user has a single whitelisted IP — whichever family their browser reached the
+app over — so an IPv4 user never appears in an `ipv6` resource, and vice versa.
+To cover both, whitelist against two resources.
+
+**Exception:** `azure` / `frontdoor` defaults to `both`, because it has never
+filtered by address family. Set `ip_version: ipv4` explicitly to restrict it.
+
+Note that not every backing service accepts IPv6 — Azure Key Vault firewall
+rules, for example, are IPv4-only. `ip_version` filters what the app sends; it
+does not check what the service accepts.
 
 ### Secrets via environment variables
 
@@ -140,6 +162,12 @@ resources:
       - <group-object-id>
     ip_whitelist:             # optional: per-list static entries
       - 1.2.3.4/32
+
+  # a UniFi Network List is family-typed, so IPv6 needs its own list
+  - cloud: unifi
+    type: networklist
+    name: ip-whitelister-ipv6
+    ip_version: ipv6
 ```
 
 Setup notes:

--- a/azure.go
+++ b/azure.go
@@ -35,6 +35,7 @@ type AzureFrontDoor struct {
 	PolicyName     string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 }
 
 type AzureStorageAccount struct {
@@ -43,6 +44,7 @@ type AzureStorageAccount struct {
 	Name           string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 }
 
 type AzureKeyVault struct {
@@ -51,6 +53,7 @@ type AzureKeyVault struct {
 	Name           string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 }
 
 type AzurePostgresServer struct {
@@ -59,6 +62,7 @@ type AzurePostgresServer struct {
 	Name           string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 }
 
 type AzureRedisCache struct {
@@ -67,6 +71,7 @@ type AzureRedisCache struct {
 	Name           string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 }
 
 type AzureCosmosDb struct {
@@ -75,6 +80,7 @@ type AzureCosmosDb struct {
 	Name           string
 	IPWhiteList    []string
 	Group          []string
+	IPVersion      string
 	Queued         bool
 }
 

--- a/azure.go
+++ b/azure.go
@@ -137,7 +137,7 @@ func (fd *AzureFrontDoor) update() int {
 
 	ips := make([]string, 0, len(w.List))
 	for key, ipval := range w.List {
-		if !w.inRange(ipval, fd.IPWhiteList) {
+		if !w.inRange(ipval, fd.IPWhiteList) && matchesIpVersion(fd.IPVersion, ipval) {
 			// ip not within static whitelist range
 			if hasGroup(fd.Group, r.getGroups(key)) {
 				ips = append(ips, ipval)
@@ -263,7 +263,7 @@ func (st *AzureStorageAccount) update() int {
 	var ipRules []storage.IPRule
 	// ip whitelist
 	for key, ipval := range w.List {
-		if !w.inRange(ipval, st.IPWhiteList) && isValidIpOrNetV4(ipval) {
+		if !w.inRange(ipval, st.IPWhiteList) && matchesIpVersion(st.IPVersion, ipval) {
 			// ip not within static whitelist range
 			if strings.Contains(ipval, "/32") {
 				// storage account wants a single IP without its /32 netmask
@@ -297,7 +297,7 @@ func (st *AzureStorageAccount) update() int {
 
 	// static ip whitelist
 	for _, ipval := range append(c.IPWhiteList, st.IPWhiteList...) {
-		if isValidIpOrNetV4(ipval) {
+		if matchesIpVersion(st.IPVersion, ipval) {
 			if strings.Contains(ipval, "/32") {
 				// storage account wants a single IP without its /32 netmask
 				ipval = deleteNetmask(ipval)
@@ -352,7 +352,7 @@ func (kv *AzureKeyVault) update() int {
 	var ipRules []keyvault.IPRule
 	// ip whitelist
 	for key, ipval := range w.List {
-		if !w.inRange(ipval, kv.IPWhiteList) && isValidIpOrNetV4(ipval) {
+		if !w.inRange(ipval, kv.IPWhiteList) && matchesIpVersion(kv.IPVersion, ipval) {
 			// ip not within static whitelist range
 			if hasGroup(kv.Group, r.getGroups(key)) {
 				ipRules = append(ipRules, keyvault.IPRule{
@@ -368,7 +368,7 @@ func (kv *AzureKeyVault) update() int {
 
 	// static ip whitelist
 	for _, ipval := range append(c.IPWhiteList, kv.IPWhiteList...) {
-		if isValidIpOrNetV4(ipval) {
+		if matchesIpVersion(kv.IPVersion, ipval) {
 			ipRules = append(ipRules, keyvault.IPRule{
 				Value: to.StringPtr(ipval),
 			})
@@ -422,7 +422,7 @@ func (pg *AzurePostgresServer) update() int {
 	newRules := make(map[string]postgresql.FirewallRule)
 	// ip whitelist
 	for key, cidr := range w.List {
-		if !w.inRange(cidr, pg.IPWhiteList) && isValidIpOrNetV4(cidr) {
+		if !w.inRange(cidr, pg.IPWhiteList) && matchesIpVersion(pg.IPVersion, cidr) {
 			// ip not within static whitelist range
 			if hasGroup(pg.Group, r.getGroups(key)) {
 				first, last, _ := getIpList(cidr)
@@ -441,7 +441,7 @@ func (pg *AzurePostgresServer) update() int {
 	}
 	// static ip whitelist
 	for _, cidr := range append(c.IPWhiteList, pg.IPWhiteList...) {
-		if isValidIpOrNetV4(cidr) {
+		if matchesIpVersion(pg.IPVersion, cidr) {
 			first, last, _ := getIpList(cidr)
 			// reg expression for creating key
 			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
@@ -531,7 +531,7 @@ func (rc *AzureRedisCache) update() int {
 	newRules := make(map[string]redis.FirewallRule)
 	// ip whitelist
 	for key, cidr := range w.List {
-		if !w.inRange(cidr, rc.IPWhiteList) && isValidIpOrNetV4(cidr) {
+		if !w.inRange(cidr, rc.IPWhiteList) && matchesIpVersion(rc.IPVersion, cidr) {
 			// ip not within static whitelist range
 			if hasGroup(rc.Group, r.getGroups(key)) {
 				first, last, _ := getIpList(cidr)
@@ -550,7 +550,7 @@ func (rc *AzureRedisCache) update() int {
 	}
 	// static ip whitelist
 	for _, cidr := range append(c.IPWhiteList, rc.IPWhiteList...) {
-		if isValidIpOrNetV4(cidr) {
+		if matchesIpVersion(rc.IPVersion, cidr) {
 			first, last, _ := getIpList(cidr)
 			// reg expression for creating key
 			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
@@ -625,7 +625,7 @@ func (cd *AzureCosmosDb) update() int {
 	var ipRules []documentdb.IPAddressOrRange
 	// ip whitelist
 	for key, ipval := range w.List {
-		if !w.inRange(ipval, cd.IPWhiteList) && isValidIpOrNetV4(ipval) {
+		if !w.inRange(ipval, cd.IPWhiteList) && matchesIpVersion(cd.IPVersion, ipval) {
 			// ip not within static whitelist range
 			if hasGroup(cd.Group, r.getGroups(key)) {
 				ipRules = append(ipRules, documentdb.IPAddressOrRange{
@@ -641,7 +641,7 @@ func (cd *AzureCosmosDb) update() int {
 
 	// static ip whitelist
 	for _, ipval := range append(c.IPWhiteList, cd.IPWhiteList...) {
-		if isValidIpOrNetV4(ipval) {
+		if matchesIpVersion(cd.IPVersion, ipval) {
 			ipRules = append(ipRules, documentdb.IPAddressOrRange{
 				IPAddressOrRange: to.StringPtr(ipval),
 			})

--- a/azure.go
+++ b/azure.go
@@ -272,7 +272,11 @@ func (st *AzureStorageAccount) update() int {
 			if hasGroup(st.Group, r.getGroups(key)) {
 				if strings.Contains(ipval, "/31") {
 					// storage account doesnt support /31, have to split both ips
-					first, last, _ := getIpList(ipval)
+					first, last, err := ipRange(ipval)
+					if err != nil {
+						log.Print("azure.AzureStorageAccount.update(): ", err)
+						continue
+					}
 					ipRules = append(ipRules, storage.IPRule{
 						IPAddressOrRange: to.StringPtr(first),
 						Action:           storage.ActionAllow,
@@ -304,7 +308,11 @@ func (st *AzureStorageAccount) update() int {
 			}
 			if strings.Contains(ipval, "/31") {
 				// storage account doesnt support /31, have to split both ips
-				first, last, _ := getIpList(ipval)
+				first, last, err := ipRange(ipval)
+				if err != nil {
+					log.Print("azure.AzureStorageAccount.update(): ", err)
+					continue
+				}
 				ipRules = append(ipRules, storage.IPRule{
 					IPAddressOrRange: to.StringPtr(first),
 					Action:           storage.ActionAllow,
@@ -425,7 +433,11 @@ func (pg *AzurePostgresServer) update() int {
 		if !w.inRange(cidr, pg.IPWhiteList) && matchesIpVersion(pg.IPVersion, cidr) {
 			// ip not within static whitelist range
 			if hasGroup(pg.Group, r.getGroups(key)) {
-				first, last, _ := getIpList(cidr)
+				first, last, err := ipRange(cidr)
+				if err != nil {
+					log.Print("azure.AzurePostgresServer.update(): ", err)
+					continue
+				}
 				newRules[key] = postgresql.FirewallRule{
 					FirewallRuleProperties: &postgresql.FirewallRuleProperties{
 						StartIPAddress: to.StringPtr(first),
@@ -442,7 +454,11 @@ func (pg *AzurePostgresServer) update() int {
 	// static ip whitelist
 	for _, cidr := range append(c.IPWhiteList, pg.IPWhiteList...) {
 		if matchesIpVersion(pg.IPVersion, cidr) {
-			first, last, _ := getIpList(cidr)
+			first, last, err := ipRange(cidr)
+			if err != nil {
+				log.Print("azure.AzurePostgresServer.update(): ", err)
+				continue
+			}
 			// reg expression for creating key
 			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
 			if err != nil {
@@ -534,7 +550,11 @@ func (rc *AzureRedisCache) update() int {
 		if !w.inRange(cidr, rc.IPWhiteList) && matchesIpVersion(rc.IPVersion, cidr) {
 			// ip not within static whitelist range
 			if hasGroup(rc.Group, r.getGroups(key)) {
-				first, last, _ := getIpList(cidr)
+				first, last, err := ipRange(cidr)
+				if err != nil {
+					log.Print("azure.AzureRedisCache.update(): ", err)
+					continue
+				}
 				newRules[key] = redis.FirewallRule{
 					FirewallRuleProperties: &redis.FirewallRuleProperties{
 						StartIP: to.StringPtr(first),
@@ -551,7 +571,11 @@ func (rc *AzureRedisCache) update() int {
 	// static ip whitelist
 	for _, cidr := range append(c.IPWhiteList, rc.IPWhiteList...) {
 		if matchesIpVersion(rc.IPVersion, cidr) {
-			first, last, _ := getIpList(cidr)
+			first, last, err := ipRange(cidr)
+			if err != nil {
+				log.Print("azure.AzureRedisCache.update(): ", err)
+				continue
+			}
 			// reg expression for creating key
 			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
 			if err != nil {

--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type ResourceConfiguration struct {
 	Name           string   `yaml:"name"`
 	IPWhiteList    []string `yaml:"ip_whitelist"`
 	Group          []string `yaml:"group"`
+	IPVersion      string   `yaml:"ip_version"`
 }
 
 var defaultConfigFile = "config/config.yaml"
@@ -96,6 +97,32 @@ func applyDefaults(resources []ResourceConfiguration, d Defaults) {
 			resources[i].ResourceGroup = d.ResourceGroup
 		}
 	}
+}
+
+// resolveIpVersion normalises a resource's ip_version and applies def when it is
+// unset. ok is false for an unsupported value; callers decide how to react.
+func resolveIpVersion(v, def string) (out string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return def, true
+	case ipVersionV4:
+		return ipVersionV4, true
+	case ipVersionV6:
+		return ipVersionV6, true
+	case ipVersionBoth:
+		return ipVersionBoth, true
+	}
+	return "", false
+}
+
+// mustResolveIpVersion resolves a resource's ip_version or exits, matching how
+// config.load() already treats an unsupported cloud or resource type.
+func mustResolveIpVersion(v, def string) string {
+	out, ok := resolveIpVersion(v, def)
+	if !ok {
+		log.Fatalln("config.load(): unsupported ip_version '" + v + "' (expected ipv4, ipv6 or both)")
+	}
+	return out
 }
 
 // applyAuthDefaults fills in auth defaults. When auth is disabled

--- a/config.go
+++ b/config.go
@@ -267,6 +267,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				nl.Name = resource.Name
 				nl.Group = resource.Group
 				nl.IPWhiteList = resource.IPWhiteList
+				nl.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				nl.client = newUnifiClient(c.Unifi)
 				nl.new(nl)
 			default:

--- a/config.go
+++ b/config.go
@@ -216,6 +216,10 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				fd.PolicyName = resource.PolicyName
 				fd.IPWhiteList = resource.IPWhiteList
 				fd.Group = resource.Group
+				// Front Door has never filtered by address family, so it defaults
+				// to both — an ipv4 default would silently stop whitelisting
+				// existing IPv6 users on upgrade.
+				fd.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionBoth)
 				fd.new(fd)
 			case "storageaccount":
 				var st AzureStorageAccount
@@ -224,6 +228,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				st.Name = resource.Name
 				st.IPWhiteList = resource.IPWhiteList
 				st.Group = resource.Group
+				st.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				st.new(st)
 			case "keyvault":
 				var kv AzureKeyVault
@@ -232,6 +237,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				kv.Name = resource.Name
 				kv.IPWhiteList = resource.IPWhiteList
 				kv.Group = resource.Group
+				kv.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				kv.new(kv)
 			case "postgres":
 				var pg AzurePostgresServer
@@ -240,6 +246,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				pg.Name = resource.Name
 				pg.IPWhiteList = resource.IPWhiteList
 				pg.Group = resource.Group
+				pg.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				pg.new(pg)
 			case "redis":
 				var rc AzureRedisCache
@@ -248,6 +255,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				rc.Name = resource.Name
 				rc.IPWhiteList = resource.IPWhiteList
 				rc.Group = resource.Group
+				rc.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				rc.new(rc)
 			case "cosmosdb":
 				var cd AzureCosmosDb
@@ -256,6 +264,7 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 				cd.Name = resource.Name
 				cd.IPWhiteList = resource.IPWhiteList
 				cd.Group = resource.Group
+				cd.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
 				cd.new(cd)
 			default:
 				log.Fatalln("config.load(): unsupported " + resource.Cloud + " resource type '" + resource.Type + "'")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -74,6 +74,16 @@ resources:
   - cloud: unifi
     type: networklist
     name: ip-whitelister # the UniFi Network List to keep in sync
+  # ip_version selects which address family a resource is whitelisted for:
+  #   ipv4 (default) | ipv6 | both
+  # A user has one IP — whichever family their browser reached the app over — so
+  # an IPv4 user never appears in an ipv6 resource, and vice versa.
+  # Note: azure frontdoor defaults to both, since it has never filtered by family.
+  # A UniFi Network List is family-typed, so IPv6 needs its own list.
+  - cloud: unifi
+    type: networklist
+    name: ip-whitelister-ipv6
+    ip_version: ipv6
 
 # This whitelist will be applied to all resources and should be static non-human IPs only
 ip_whitelist:

--- a/config_test.go
+++ b/config_test.go
@@ -78,6 +78,72 @@ func TestLoadResourceConfigs(t *testing.T) {
 	}
 }
 
+func TestResolveIpVersion(t *testing.T) {
+	tests := []struct {
+		in     string
+		def    string
+		want   string
+		wantOk bool
+	}{
+		// unset falls back to the per-resource-type default
+		{"", ipVersionV4, ipVersionV4, true},
+		{"", ipVersionBoth, ipVersionBoth, true},
+
+		// explicit values win over the default, and are normalised
+		{"ipv4", ipVersionBoth, ipVersionV4, true},
+		{"ipv6", ipVersionV4, ipVersionV6, true},
+		{"both", ipVersionV4, ipVersionBoth, true},
+		{"IPv6", ipVersionV4, ipVersionV6, true},
+		{"  Both  ", ipVersionV4, ipVersionBoth, true},
+
+		// anything else is rejected
+		{"ipv5", ipVersionV4, "", false},
+		{"v6", ipVersionV4, "", false},
+		{"yes", ipVersionV4, "", false},
+	}
+
+	for _, f := range tests {
+		got, ok := resolveIpVersion(f.in, f.def)
+		if ok != f.wantOk {
+			t.Errorf("resolveIpVersion(%q, %q) ok = %v, want %v", f.in, f.def, ok, f.wantOk)
+			continue
+		}
+		if got != f.want {
+			t.Errorf("resolveIpVersion(%q, %q) = %q, want %q", f.in, f.def, got, f.want)
+		}
+	}
+}
+
+func TestLoadResourceConfigsIpVersion(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "" +
+		"resources:\n" +
+		"  - cloud: unifi\n" +
+		"    type: networklist\n" +
+		"    name: list-v6\n" +
+		"    ip_version: ipv6\n" +
+		"  - cloud: unifi\n" +
+		"    type: networklist\n" +
+		"    name: list-default\n"
+	if err := os.WriteFile(filepath.Join(dir, "app.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resources, err := loadResourceConfigs(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].IPVersion != "ipv6" {
+		t.Errorf("ip_version did not unmarshal, got %q want %q", resources[0].IPVersion, "ipv6")
+	}
+	if resources[1].IPVersion != "" {
+		t.Errorf("omitted ip_version should stay empty, got %q", resources[1].IPVersion)
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	defaults := Defaults{SubscriptionId: "sub-default", ResourceGroup: "rg-default"}
 	resources := []ResourceConfiguration{

--- a/docs/superpowers/plans/2026-08-24-ip-version-ipv6.md
+++ b/docs/superpowers/plans/2026-08-24-ip-version-ipv6.md
@@ -1,0 +1,992 @@
+# `ip_version` / IPv6 Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a provider-agnostic `ip_version` field (`ipv4` default / `ipv6` / `both`) to every resource in `config.yaml`, so a user's IPv6 address can be synced into a UniFi `ipv6-address-group` Network List.
+
+**Architecture:** One pure helper, `matchesIpVersion(want, ip)`, replaces the hardcoded `isValidIpOrNetV4` guard at all twelve existing whitelist call sites plus one missing guard in Front Door. Each resource struct carries an `IPVersion` string that `config.load()` resolves and validates. Separately, `getIpList` — which silently truncates IPv6 masks to four bytes — is replaced by a non-enumerating, family-agnostic `ipRange`.
+
+**Tech Stack:** Go (flat `package main` at repo root), `net` stdlib, `gopkg.in/yaml.v2`, standard `testing`.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-ip-version-ipv6-design.md`
+
+**Branch:** `feat/ip-version-ipv6` (already created; the spec commit is on it)
+
+---
+
+## File Structure
+
+No new files. All changes land in the existing flat package:
+
+| File | Responsibility after this change |
+|---|---|
+| `functions.go` | Gains `matchesIpVersion` + `ipRange`; loses `isValidIpOrNetV4` + `getIpList` |
+| `config.go` | Gains `ip_version` on `ResourceConfiguration`, plus `resolveIpVersion` / `mustResolveIpVersion`; each of the 7 `case` arms plumbs `IPVersion` onto its resource struct |
+| `unifi.go` | `UnifiNetworkList.IPVersion`; `buildMembers` guards switch to `matchesIpVersion`; `unifiMember` becomes family-aware |
+| `azure.go` | `IPVersion` on all 6 structs; 10 guards swapped; Front Door's missing guard added; 6 `getIpList` calls become `ipRange` |
+| `functions_test.go`, `config_test.go`, `unifi_test.go` | Coverage for the above |
+| `config/config.yaml`, `config.dev/config.yaml`, `README.md` | Document `ip_version` |
+
+**Ordering rule:** every task must leave the tree compiling and green. The two old helpers are therefore kept until Task 8, after every caller has moved off them.
+
+---
+
+## Task 1: `matchesIpVersion` helper
+
+**Files:**
+- Modify: `functions.go` (add after `isValidIpOrNetV4`, ~line 88)
+- Test: `functions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `functions_test.go`:
+
+```go
+func TestMatchesIpVersion(t *testing.T) {
+	tests := []struct {
+		want    string
+		ip      string
+		success bool
+	}{
+		// empty want behaves as ipv4, preserving the old isValidIpOrNetV4 default
+		{"", "1.2.3.4", true},
+		{"", "1.2.3.0/24", true},
+		{"", "2a00:11c7:1234:b801::1", false},
+
+		{"ipv4", "1.2.3.4", true},
+		{"ipv4", "1.2.3.4/32", true},
+		{"ipv4", "1.2.3.0/24", true},
+		{"ipv4", "2a00:11c7:1234:b801::1", false},
+		{"ipv4", "2a00:11c7:1234:b801::/64", false},
+
+		{"ipv6", "2a00:11c7:1234:b801::1", true},
+		{"ipv6", "2a00:11c7:1234:b801::1/128", true},
+		{"ipv6", "2a00:11c7:1234:b801::/64", true},
+		{"ipv6", "1.2.3.4", false},
+		{"ipv6", "1.2.3.0/24", false},
+
+		{"both", "1.2.3.4", true},
+		{"both", "2a00:11c7:1234:b801::1", true},
+		{"both", "1.2.3.0/24", true},
+		{"both", "2a00:11c7:1234:b801::/64", true},
+
+		// unparseable input is never a match, whatever the family
+		{"ipv4", "not-an-ip", false},
+		{"ipv6", "not-an-ip", false},
+		{"both", "not-an-ip", false},
+		{"", "not-an-ip", false},
+	}
+
+	for _, f := range tests {
+		success := matchesIpVersion(f.want, f.ip)
+		if success != f.success {
+			t.Errorf("matchesIpVersion(%q, %q) = %v, want %v", f.want, f.ip, success, f.success)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run TestMatchesIpVersion -v`
+Expected: FAIL — `undefined: matchesIpVersion`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the constants next to the existing `IpType` block in `functions.go` (after the `const (...)` that defines `Undefined`/`IpV4`/`IpV6`):
+
+```go
+// Supported values for a resource's ip_version field.
+const (
+	ipVersionV4   = "ipv4"
+	ipVersionV6   = "ipv6"
+	ipVersionBoth = "both"
+)
+```
+
+Add the helper immediately after `isValidIpOrNetV4` in `functions.go`:
+
+```go
+// matchesIpVersion reports whether ip is a parseable address (with or without a
+// netmask) of the address family selected by a resource's ip_version. An empty
+// want means ipv4, which is the default for every resource type except Front
+// Door. Unparseable input never matches, so this fully replaces the
+// isValidIpOrNetV4 guard it supersedes.
+func matchesIpVersion(want, ip string) bool {
+	t, err := ipVersion(ip)
+	if err != nil {
+		return false
+	}
+	switch want {
+	case ipVersionV6:
+		return t == IpV6
+	case ipVersionBoth:
+		return true
+	default:
+		return t == IpV4
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test . -run 'TestMatchesIpVersion|TestIsValidIpOrNetV4|TestIpVersion' -v`
+Expected: PASS (all three)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions.go functions_test.go
+git commit -m "feat: add matchesIpVersion address-family filter"
+```
+
+---
+
+## Task 2: `ipRange` replacing `getIpList`
+
+`getIpList` computes a CIDR's bounds via `binary.BigEndian.Uint32`, which reads only the first four bytes of a sixteen-byte IPv6 mask and address — no panic, just wrong answers. It also materialises every address in the range, which is impossible for IPv6 and wasteful for large IPv4 blocks. Nothing consumes its third return value: all six `azure.go` call sites are `first, last, _ :=`, and only `functions_test.go` reads `all`.
+
+**Files:**
+- Modify: `functions.go` (add after `getIpList`, ~line 66)
+- Test: `functions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `functions_test.go`:
+
+```go
+func TestIpRange(t *testing.T) {
+	tests := []struct {
+		cidr         string
+		successFirst string
+		successLast  string
+	}{
+		// IPv4 — same expectations the old getIpList test asserted
+		{"10.0.0.0/31", "10.0.0.0", "10.0.0.1"},
+		{"200.0.0.0/30", "200.0.0.0", "200.0.0.3"},
+		{"10.0.0.1", "10.0.0.1", "10.0.0.1"},
+		{"1.2.3.4/32", "1.2.3.4", "1.2.3.4"},
+		{"10.0.0.0/24", "10.0.0.0", "10.0.0.255"},
+
+		// IPv6 — the family the old implementation silently corrupted
+		{"2a00:11c7:1234:b801::/64", "2a00:11c7:1234:b801::", "2a00:11c7:1234:b801:ffff:ffff:ffff:ffff"},
+		{"2a00:11c7:1234:b801::1/128", "2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+	}
+
+	for _, f := range tests {
+		first, last, err := ipRange(f.cidr)
+		if err != nil {
+			t.Errorf("ipRange(%q) returned unexpected error %v", f.cidr, err)
+			continue
+		}
+		if first != f.successFirst {
+			t.Errorf("ipRange(%q) first = %v, want %v", f.cidr, first, f.successFirst)
+		}
+		if last != f.successLast {
+			t.Errorf("ipRange(%q) last = %v, want %v", f.cidr, last, f.successLast)
+		}
+	}
+}
+
+// TestIpRangeInvalid asserts a bad value returns an error rather than calling
+// log.Fatal and taking the process down mid-reconcile, as getIpList did.
+func TestIpRangeInvalid(t *testing.T) {
+	for _, cidr := range []string{"not-an-ip", "10.0.0.0/99", "10.0.0.0/", ""} {
+		if _, _, err := ipRange(cidr); err == nil {
+			t.Errorf("ipRange(%q) should return an error", cidr)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run TestIpRange -v`
+Expected: FAIL — `undefined: ipRange`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `functions.go`, immediately after `getIpList`:
+
+```go
+// ipRange returns the first and last address of cidr. Bounds are computed with
+// byte-wise mask arithmetic, so it works for IPv4 and IPv6 alike — unlike
+// getIpList, which reads a 16-byte IPv6 mask as a uint32 and returns nonsense.
+// It deliberately does not enumerate the range: an IPv6 /64 holds 1.8e19
+// addresses, and no caller needs the full list. A bare address is its own first
+// and last. An unparseable value returns an error rather than exiting.
+func ipRange(cidr string) (first string, last string, err error) {
+	if !strings.Contains(cidr, "/") {
+		if _, err := ipVersion(cidr); err != nil {
+			return "", "", err
+		}
+		return cidr, cidr, nil
+	}
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", "", err
+	}
+
+	firstIP := make(net.IP, len(network.IP))
+	lastIP := make(net.IP, len(network.IP))
+	for i := range network.IP {
+		firstIP[i] = network.IP[i] & network.Mask[i]
+		lastIP[i] = network.IP[i] | ^network.Mask[i]
+	}
+	return firstIP.String(), lastIP.String(), nil
+}
+```
+
+`net.ParseCIDR` returns `IP` and `Mask` of matching length (4 bytes for IPv4, 16 for IPv6), so the loop is safe for both families.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test . -run 'TestIpRange|TestGetIpList' -v`
+Expected: PASS (both — `getIpList` is still present and untouched)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions.go functions_test.go
+git commit -m "feat: add family-agnostic ipRange without enumeration"
+```
+
+---
+
+## Task 3: `ip_version` config field and resolution
+
+**Files:**
+- Modify: `config.go:41-50` (`ResourceConfiguration`), plus new helpers
+- Test: `config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `config_test.go`:
+
+```go
+func TestResolveIpVersion(t *testing.T) {
+	tests := []struct {
+		in      string
+		def     string
+		want    string
+		wantOk  bool
+	}{
+		// unset falls back to the per-resource-type default
+		{"", ipVersionV4, ipVersionV4, true},
+		{"", ipVersionBoth, ipVersionBoth, true},
+
+		// explicit values win over the default, and are normalised
+		{"ipv4", ipVersionBoth, ipVersionV4, true},
+		{"ipv6", ipVersionV4, ipVersionV6, true},
+		{"both", ipVersionV4, ipVersionBoth, true},
+		{"IPv6", ipVersionV4, ipVersionV6, true},
+		{"  Both  ", ipVersionV4, ipVersionBoth, true},
+
+		// anything else is rejected
+		{"ipv5", ipVersionV4, "", false},
+		{"v6", ipVersionV4, "", false},
+		{"yes", ipVersionV4, "", false},
+	}
+
+	for _, f := range tests {
+		got, ok := resolveIpVersion(f.in, f.def)
+		if ok != f.wantOk {
+			t.Errorf("resolveIpVersion(%q, %q) ok = %v, want %v", f.in, f.def, ok, f.wantOk)
+			continue
+		}
+		if got != f.want {
+			t.Errorf("resolveIpVersion(%q, %q) = %q, want %q", f.in, f.def, got, f.want)
+		}
+	}
+}
+
+func TestLoadResourceConfigsIpVersion(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "" +
+		"resources:\n" +
+		"  - cloud: unifi\n" +
+		"    type: networklist\n" +
+		"    name: list-v6\n" +
+		"    ip_version: ipv6\n" +
+		"  - cloud: unifi\n" +
+		"    type: networklist\n" +
+		"    name: list-default\n"
+	if err := os.WriteFile(filepath.Join(dir, "app.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resources, err := loadResourceConfigs(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].IPVersion != "ipv6" {
+		t.Errorf("ip_version did not unmarshal, got %q want %q", resources[0].IPVersion, "ipv6")
+	}
+	if resources[1].IPVersion != "" {
+		t.Errorf("omitted ip_version should stay empty, got %q", resources[1].IPVersion)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run 'TestResolveIpVersion|TestLoadResourceConfigsIpVersion' -v`
+Expected: FAIL — `undefined: resolveIpVersion` and `resources[0].IPVersion undefined`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `config.go`, add the field to `ResourceConfiguration`:
+
+```go
+type ResourceConfiguration struct {
+	Cloud          string   `yaml:"cloud"`
+	Type           string   `yaml:"type"`
+	SubscriptionId string   `yaml:"subscription_id"`
+	ResourceGroup  string   `yaml:"resource_group"`
+	PolicyName     string   `yaml:"policy_name"`
+	Name           string   `yaml:"name"`
+	IPWhiteList    []string `yaml:"ip_whitelist"`
+	Group          []string `yaml:"group"`
+	IPVersion      string   `yaml:"ip_version"`
+}
+```
+
+Add both helpers to `config.go`, immediately after `applyDefaults`:
+
+```go
+// resolveIpVersion normalises a resource's ip_version and applies def when it is
+// unset. ok is false for an unsupported value; callers decide how to react.
+func resolveIpVersion(v, def string) (out string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return def, true
+	case ipVersionV4:
+		return ipVersionV4, true
+	case ipVersionV6:
+		return ipVersionV6, true
+	case ipVersionBoth:
+		return ipVersionBoth, true
+	}
+	return "", false
+}
+
+// mustResolveIpVersion resolves a resource's ip_version or exits, matching how
+// config.load() already treats an unsupported cloud or resource type.
+func mustResolveIpVersion(v, def string) string {
+	out, ok := resolveIpVersion(v, def)
+	if !ok {
+		log.Fatalln("config.load(): unsupported ip_version '" + v + "' (expected ipv4, ipv6 or both)")
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test . -run 'TestResolveIpVersion|TestLoadResourceConfigs' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config.go config_test.go
+git commit -m "feat: add ip_version resource config field"
+```
+
+---
+
+## Task 4: UniFi — family filter and family-aware member format
+
+`unifiMember` currently does `strings.TrimSuffix(ip, "/32")`. Naively adding `/128` alongside it would be a bug: `/32` is a single-host mask only for IPv4 — on IPv6 it is a very large subnet, and `2a00:11c7::/32` must keep its mask. The check has to be family-aware.
+
+**Files:**
+- Modify: `unifi.go:23-28` (struct), `unifi.go:222`, `unifi.go:232`, `unifi.go:239-246` (`unifiMember`)
+- Modify: `config.go:236-245` (the `unifi` → `networklist` case arm)
+- Test: `unifi_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `unifi_test.go`:
+
+```go
+// TestUnifiMemberFamilyAware asserts single hosts lose their mask while real
+// subnets keep theirs — including the trap that /32 is a host mask on IPv4 but a
+// large subnet on IPv6.
+func TestUnifiMemberFamilyAware(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want string
+	}{
+		{"1.1.1.1/32", "1.1.1.1"},
+		{"1.1.1.1", "1.1.1.1"},
+		{"85.0.0.0/24", "85.0.0.0/24"},
+		{"2a00:11c7:1234:b801::1/128", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::/64", "2a00:11c7:1234:b801::/64"},
+		// /32 on IPv6 is a subnet, not a host — it must survive untouched
+		{"2a00:11c7::/32", "2a00:11c7::/32"},
+		// unparseable input is passed through unchanged
+		{"not-an-ip", "not-an-ip"},
+	}
+
+	for _, f := range tests {
+		if got := unifiMember(f.ip); got != f.want {
+			t.Errorf("unifiMember(%q) = %q, want %q", f.ip, got, f.want)
+		}
+	}
+}
+
+func TestBuildMembersIPv6(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = []string{"9.9.9.9/32", "2a00:1111::5/128"} // one of each family
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "v6", Group: nil, IPVersion: ipVersionV6}
+	list := map[string]string{
+		"alice": "1.1.1.1/32",                  // IPv4 -> excluded from a v6 list
+		"bob":   "2a00:2222:3333:4444::1/128",  // IPv6 -> included, mask stripped
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	want := map[string]bool{
+		"2a00:2222:3333:4444::1": true, // bob, host mask stripped
+		"2a00:1111::5":           true, // static v6 host, mask stripped
+	}
+	if len(got) != len(want) {
+		t.Fatalf("buildMembers = %v, want keys %v", got, want)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected member %q in %v (v6 list must exclude IPv4)", m, got)
+		}
+	}
+}
+
+func TestBuildMembersBothFamilies(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = nil
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "mixed", Group: nil, IPVersion: ipVersionBoth}
+	list := map[string]string{
+		"alice": "1.1.1.1/32",
+		"bob":   "2a00:2222::1/128",
+		"bad":   "not-an-ip",
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	want := map[string]bool{"1.1.1.1": true, "2a00:2222::1": true}
+	if len(got) != len(want) {
+		t.Fatalf("buildMembers = %v, want keys %v", got, want)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected member %q in %v", m, got)
+		}
+	}
+}
+
+// TestBuildMembersDefaultsToIPv4 pins the upgrade guarantee: a list with no
+// ip_version set behaves exactly as it did before this field existed.
+func TestBuildMembersDefaultsToIPv4(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = nil
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "legacy", Group: nil} // IPVersion zero value
+	list := map[string]string{
+		"alice": "1.1.1.1/32",
+		"bob":   "2a00:2222::1/128",
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	if len(got) != 1 || got[0] != "1.1.1.1" {
+		t.Errorf("buildMembers = %v, want [1.1.1.1] (unset ip_version means ipv4)", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run 'TestUnifiMember|TestBuildMembers' -v`
+Expected: FAIL — `unknown field IPVersion in struct literal` and `TestUnifiMemberFamilyAware` failing on the IPv6 cases
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `unifi.go`, add the field to `UnifiNetworkList`:
+
+```go
+type UnifiNetworkList struct {
+	Name        string   // the Network List / firewall group name
+	Group       []string // optional AzureAD group filter
+	IPWhiteList []string // optional per-list static entries
+	IPVersion   string   // ipv4 (default) | ipv6 | both
+	client      unifiClient
+}
+```
+
+In `unifi.go:222`, swap the dynamic-whitelist guard:
+
+```go
+		if !w.inRange(ip, nl.IPWhiteList) && matchesIpVersion(nl.IPVersion, ip) {
+```
+
+In `unifi.go:232`, swap the static-whitelist guard:
+
+```go
+		if matchesIpVersion(nl.IPVersion, ip) {
+```
+
+Replace `unifiMember` in `unifi.go:239-246` entirely:
+
+```go
+// unifiMember formats an address for a UniFi firewall group. UniFi stores single
+// hosts as bare IPs — its UI rejects a host netmask ("enter single host
+// addresses without the subnet mask") — so we strip the single-host mask while
+// leaving real subnets (e.g. /24) untouched. Matching UniFi's stored form also
+// keeps sameMembers() stable, so an unchanged whitelist doesn't force a PUT on
+// every reconcile. The host mask is family-dependent: /32 for IPv4, /128 for
+// IPv6. On IPv6 a /32 is a large subnet and must be preserved, so the family
+// must be resolved before trimming.
+func unifiMember(ip string) string {
+	t, err := ipVersion(ip)
+	if err != nil {
+		return ip
+	}
+	if t == IpV6 {
+		return strings.TrimSuffix(ip, "/128")
+	}
+	return strings.TrimSuffix(ip, "/32")
+}
+```
+
+In `config.go`, the `unifi` → `networklist` arm gains one line:
+
+```go
+			case "networklist":
+				var nl UnifiNetworkList
+				nl.Name = resource.Name
+				nl.Group = resource.Group
+				nl.IPWhiteList = resource.IPWhiteList
+				nl.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+				nl.client = newUnifiClient(c.Unifi)
+				nl.new(nl)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test . -run 'TestUnifiMember|TestBuildMembers|TestSameMembers|TestUpdate' -v`
+Expected: PASS — including the four pre-existing `TestBuildMembers*` tests, which construct `UnifiNetworkList` without `IPVersion` and must keep their current IPv4 behaviour
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unifi.go unifi_test.go config.go
+git commit -m "feat: support ip_version on unifi network lists"
+```
+
+---
+
+## Task 5: Azure — plumb `IPVersion` onto the resource structs
+
+Plumbing only; the field is unused until Task 6, so the tree stays green.
+
+**Files:**
+- Modify: `azure.go:32-78` (all six structs)
+- Modify: `config.go:183-232` (all six `azure` case arms)
+
+- [ ] **Step 1: Add the field to all six structs**
+
+In `azure.go`, add `IPVersion string` to `AzureFrontDoor`, `AzureStorageAccount`, `AzureKeyVault`, `AzurePostgresServer`, `AzureRedisCache` and `AzureCosmosDb`. For example:
+
+```go
+type AzureFrontDoor struct {
+	SubscriptionId string
+	ResourceGroup  string
+	PolicyName     string
+	IPWhiteList    []string
+	Group          []string
+	IPVersion      string
+}
+```
+
+`AzureCosmosDb` keeps its trailing `Queued bool` field; add `IPVersion string` above it.
+
+- [ ] **Step 2: Plumb it in `config.load()`**
+
+In `config.go`, add one line to each of the six `azure` case arms, before the `.new(...)` call. Front Door defaults to `both`; every other type defaults to `ipv4`:
+
+```go
+			case "frontdoor":
+				// Front Door has never filtered by address family, so it defaults
+				// to both — an ipv4 default would silently stop whitelisting
+				// existing IPv6 users on upgrade.
+				fd.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionBoth)
+			case "storageaccount":
+				st.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+			case "keyvault":
+				kv.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+			case "postgres":
+				pg.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+			case "redis":
+				rc.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+			case "cosmosdb":
+				cd.IPVersion = mustResolveIpVersion(resource.IPVersion, ipVersionV4)
+```
+
+The `case` labels above are shown only to identify which arm each line belongs in — insert the single assignment into the existing arm, do not duplicate the `case` statements. The arms are at `config.go:185` (frontdoor), `:193` (storageaccount), `:201` (keyvault), `:209` (postgres), `:217` (redis — note the label is `redis`, not `rediscache`) and `:225` (cosmosdb).
+
+- [ ] **Step 3: Verify it compiles and everything still passes**
+
+Run: `go build ./... && go vet ./...`
+Expected: no output (success)
+
+Run: `go test . -run 'TestMatchesIpVersion|TestIpRange|TestResolveIpVersion|TestLoadResourceConfigs|TestBuildMembers|TestUnifiMember' -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add azure.go config.go
+git commit -m "feat: plumb ip_version onto azure resource structs"
+```
+
+---
+
+## Task 6: Azure — apply the family filter
+
+Ten existing guards swap to `matchesIpVersion`, and Front Door gains the guard it has always been missing.
+
+**Files:**
+- Modify: `azure.go:134` (Front Door — **add**), `azure.go:260`, `:294`, `:349`, `:365`, `:419`, `:438`, `:528`, `:547`, `:622`, `:638`
+
+- [ ] **Step 1: Add Front Door's missing guard**
+
+`azure.go:134` is the only whitelist guard in the codebase without a family check. Change:
+
+```go
+		if !w.inRange(ipval, fd.IPWhiteList) {
+```
+
+to:
+
+```go
+		if !w.inRange(ipval, fd.IPWhiteList) && matchesIpVersion(fd.IPVersion, ipval) {
+```
+
+Because `config.load()` defaults Front Door to `both`, this is behaviour-preserving by default and only filters when an operator asks for it.
+
+- [ ] **Step 2: Swap the ten existing guards**
+
+Replace each `isValidIpOrNetV4(x)` with `matchesIpVersion(<receiver>.IPVersion, x)`, using the receiver already in scope at that line:
+
+| Line | Receiver | New expression |
+|---|---|---|
+| 260 | `st` | `!w.inRange(ipval, st.IPWhiteList) && matchesIpVersion(st.IPVersion, ipval)` |
+| 294 | `st` | `matchesIpVersion(st.IPVersion, ipval)` |
+| 349 | `kv` | `!w.inRange(ipval, kv.IPWhiteList) && matchesIpVersion(kv.IPVersion, ipval)` |
+| 365 | `kv` | `matchesIpVersion(kv.IPVersion, ipval)` |
+| 419 | `pg` | `!w.inRange(cidr, pg.IPWhiteList) && matchesIpVersion(pg.IPVersion, cidr)` |
+| 438 | `pg` | `matchesIpVersion(pg.IPVersion, cidr)` |
+| 528 | `rc` | `!w.inRange(cidr, rc.IPWhiteList) && matchesIpVersion(rc.IPVersion, cidr)` |
+| 547 | `rc` | `matchesIpVersion(rc.IPVersion, cidr)` |
+| 622 | `cd` | `!w.inRange(ipval, cd.IPWhiteList) && matchesIpVersion(cd.IPVersion, ipval)` |
+| 638 | `cd` | `matchesIpVersion(cd.IPVersion, ipval)` |
+
+Line numbers shift as you edit — work bottom-up (638 first, 260 last) so earlier line numbers stay valid.
+
+- [ ] **Step 3: Verify no callers remain**
+
+Run: `grep -n 'isValidIpOrNetV4' azure.go unifi.go`
+Expected: no output
+
+- [ ] **Step 4: Verify it builds and tests pass**
+
+Run: `go build ./... && go vet ./...`
+Expected: no output
+
+Run: `go test . -run 'TestMatchesIpVersion|TestIpRange|TestResolveIpVersion|TestLoadResourceConfigs|TestBuildMembers|TestUnifiMember|TestUpdate' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add azure.go
+git commit -m "feat: filter azure whitelists by ip_version, fix missing front door guard"
+```
+
+---
+
+## Task 7: Azure — move from `getIpList` to `ipRange`
+
+Six call sites, all currently discarding the error via `_`. `ipRange` returns an error instead of calling `log.Fatal`, so each site must handle it.
+
+**Files:**
+- Modify: `azure.go:269`, `:301`, `:422`, `:439`, `:531`, `:548`
+
+- [ ] **Step 1: Update the two Storage Account sites**
+
+At `azure.go:269` (inside the dynamic-whitelist loop, within the `/31` split branch), change:
+
+```go
+					first, last, _ := getIpList(ipval)
+```
+
+to:
+
+```go
+					first, last, err := ipRange(ipval)
+					if err != nil {
+						log.Print("azure.AzureStorageAccount.update(): ", err)
+						continue
+					}
+```
+
+At `azure.go:301` (the static-whitelist loop, same `/31` branch), change:
+
+```go
+				first, last, _ := getIpList(ipval)
+```
+
+to:
+
+```go
+				first, last, err := ipRange(ipval)
+				if err != nil {
+					log.Print("azure.AzureStorageAccount.update(): ", err)
+					continue
+				}
+```
+
+- [ ] **Step 2: Update the two Postgres sites**
+
+At `azure.go:422`:
+
+```go
+				first, last, err := ipRange(cidr)
+				if err != nil {
+					log.Print("azure.AzurePostgresServer.update(): ", err)
+					continue
+				}
+```
+
+At `azure.go:439`:
+
+```go
+			first, last, err := ipRange(cidr)
+			if err != nil {
+				log.Print("azure.AzurePostgresServer.update(): ", err)
+				continue
+			}
+```
+
+Note `azure.go:441` already declares `err` from `regexp.Compile` a few lines below with `:=`. After this change that becomes a redeclaration in the same scope — change line 441's `reg, err := regexp.Compile(...)` to `reg, err = regexp.Compile(...)`. Compile after editing to confirm.
+
+- [ ] **Step 3: Update the two Redis Cache sites**
+
+At `azure.go:531` and `azure.go:548`, apply the identical pattern with the `azure.AzureRedisCache.update(): ` log prefix:
+
+```go
+				first, last, err := ipRange(cidr)
+				if err != nil {
+					log.Print("azure.AzureRedisCache.update(): ", err)
+					continue
+				}
+```
+
+Check whether either site is followed by a `regexp.Compile` that also uses `:=` on `err`, as Postgres is, and switch that to `=` if so.
+
+- [ ] **Step 4: Verify no callers remain**
+
+Run: `grep -n 'getIpList' azure.go`
+Expected: no output
+
+- [ ] **Step 5: Verify it builds and tests pass**
+
+Run: `go build ./... && go vet ./...`
+Expected: no output
+
+Run: `go test . -run 'TestIpRange|TestGetIpList|TestMatchesIpVersion|TestBuildMembers' -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add azure.go
+git commit -m "refactor: use ipRange instead of getIpList in azure resources"
+```
+
+---
+
+## Task 8: Delete the superseded helpers
+
+Both are now unreferenced outside their own tests.
+
+**Files:**
+- Modify: `functions.go` (delete `isValidIpOrNetV4` ~line 84, delete `getIpList` ~line 38)
+- Modify: `functions_test.go` (delete `TestIsValidIpOrNetV4`, `TestGetIpList`)
+
+- [ ] **Step 1: Confirm nothing but the tests reference them**
+
+Run: `grep -rn 'isValidIpOrNetV4\|getIpList' --include='*.go' .`
+Expected: hits only in `functions.go` (the definitions) and `functions_test.go` (the two tests)
+
+- [ ] **Step 2: Delete `isValidIpOrNetV4` from `functions.go`**
+
+Remove:
+
+```go
+// isValidIpOrNetV4 reports whether ip is a parseable IPv4 address or IPv4 CIDR.
+func isValidIpOrNetV4(ip string) bool {
+	ipType, err := ipVersion(ip)
+	return err == nil && ipType == IpV4
+}
+```
+
+- [ ] **Step 3: Delete `getIpList` from `functions.go`**
+
+Remove the whole `getIpList` function (the one with the `binary.BigEndian` arithmetic and the enumeration loop), including its `// function to get ips in subnet range` comment.
+
+- [ ] **Step 4: Drop the now-unused `encoding/binary` import**
+
+`getIpList` was the only user of `binary`. Remove `"encoding/binary"` from the `import` block at the top of `functions.go`. Confirm with:
+
+Run: `grep -n 'binary\.' functions.go`
+Expected: no output
+
+- [ ] **Step 5: Delete the two obsolete tests**
+
+Remove `TestGetIpList` and `TestIsValidIpOrNetV4` from `functions_test.go`. `TestGetIpList` was the only user of `reflect` in that file — check and remove the `"reflect"` import if nothing else needs it:
+
+Run: `grep -n 'reflect\.' functions_test.go`
+Expected: no output (if so, drop the import)
+
+- [ ] **Step 6: Verify the full suite**
+
+Run: `go build ./... && go vet ./...`
+Expected: no output
+
+Run: `go test ./...`
+Expected: PASS. This run includes the Docker-backed Redis suite (`ory/dockertest`) and takes roughly 60 seconds; Docker/OrbStack must be running.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions.go functions_test.go
+git commit -m "refactor: remove isValidIpOrNetV4 and getIpList"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `config/config.yaml`, `config.dev/config.yaml`, `README.md`
+- Check: `helm/ip-whitelister/README.md`
+
+- [ ] **Step 1: Document the field in the sample configs**
+
+In `config/config.yaml`, above the `resources:` list, add a comment describing the field, and add a UniFi IPv6 example alongside the existing UniFi entry (around line 74):
+
+```yaml
+  # ip_version selects which address family a resource is whitelisted for:
+  #   ipv4 (default) | ipv6 | both
+  # A user has one IP — whichever family their browser reached the app over — so
+  # an IPv4 user never appears in an ipv6 resource, and vice versa.
+  # Note: azure frontdoor defaults to both, since it has never filtered by family.
+  - cloud: unifi
+    type: networklist
+    name: example-allow-list-ipv6
+    ip_version: ipv6
+```
+
+Mirror the same comment and example in `config.dev/config.yaml` (near its existing `unifi` resource around line 31).
+
+- [ ] **Step 2: Document it in the README**
+
+Add a row to the config key table, after the `ip_whitelist` row at `README.md:69`:
+
+```markdown
+| `ip_version`   | Per-resource address family: `ipv4` (default), `ipv6`, or `both`. |
+```
+
+Then add this subsection immediately after that table (before `### Secrets via environment variables` at line 71):
+
+```markdown
+### Address families (`ip_version`)
+
+Each entry in `resources` takes an optional `ip_version`:
+
+| Value  | Effect                                              |
+| ------ | --------------------------------------------------- |
+| `ipv4` | Only IPv4 addresses are whitelisted. **Default.**   |
+| `ipv6` | Only IPv6 addresses are whitelisted.                |
+| `both` | Both families are whitelisted.                      |
+
+A user has a single whitelisted IP — whichever family their browser reached the
+app over — so an IPv4 user never appears in an `ipv6` resource, and vice versa.
+To cover both, whitelist against two resources.
+
+**Exception:** `azure` / `frontdoor` defaults to `both`, because it has never
+filtered by address family. Set `ip_version: ipv4` explicitly to restrict it.
+
+Note that not every backing service accepts IPv6 — Azure Key Vault firewall
+rules, for example, are IPv4-only. `ip_version` filters what the app sends; it
+does not check what the service accepts.
+```
+
+Finally, extend the UniFi example at `README.md:135-143` with an IPv6 list, since UniFi Network Lists are family-typed (`address-group` vs `ipv6-address-group`) and need one list per family:
+
+```yaml
+resources:
+  - cloud: unifi
+    type: networklist
+    name: ip-whitelister      # the Network List to manage
+    group:                    # optional: only whitelist users in these AzureAD groups
+      - <group-object-id>
+    ip_whitelist:             # optional: per-list static entries
+      - 1.2.3.4/32
+
+  # a UniFi Network List is family-typed, so IPv6 needs its own list
+  - cloud: unifi
+    type: networklist
+    name: ip-whitelister-ipv6
+    ip_version: ipv6
+```
+
+- [ ] **Step 3: Check the Helm chart README**
+
+Run: `grep -n 'ip_whitelist\|resources:' helm/ip-whitelister/README.md`
+
+If it documents resource fields, add `ip_version` there too. If it only documents chart values and points at the app README for resource schema, leave it alone.
+
+- [ ] **Step 4: Verify nothing broke**
+
+Run: `go test ./...`
+Expected: PASS (`TestLoad` reads `config/config.yaml`, so a YAML syntax error there fails the suite)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/config.yaml config.dev/config.yaml README.md helm/ip-whitelister/README.md
+git commit -m "docs: document ip_version resource field"
+```
+
+---
+
+## Done criteria
+
+- [ ] `go test ./...` passes with Docker running
+- [ ] `grep -rn 'isValidIpOrNetV4\|getIpList' --include='*.go' .` returns nothing
+- [ ] A `unifi` / `networklist` resource with `ip_version: ipv6` builds members from IPv6 whitelist entries with `/128` stripped
+- [ ] A resource with no `ip_version` behaves exactly as it did before this branch
+- [ ] An invalid `ip_version` value stops startup with a clear message
+
+## Follow-up (not this plan)
+
+The `/128` member format and UniFi's `ipv6-address-group` handling are unverified against a live gateway — the same open item already tracked for the `/32` behaviour. Add both to the outstanding UniFi live-gateway validation task rather than blocking this work.

--- a/docs/superpowers/specs/2026-08-24-ip-version-ipv6-design.md
+++ b/docs/superpowers/specs/2026-08-24-ip-version-ipv6-design.md
@@ -1,0 +1,233 @@
+# IPv6 support via a shared `ip_version` resource field — design
+
+**Date:** 2026-08-24
+**Status:** Approved (design)
+**Author:** Alec Pinson
+
+## Summary
+
+Add a provider-agnostic `ip_version` field to every resource in `config.yaml`,
+selecting which IP address family that resource is whitelisted for: `ipv4`
+(default), `ipv6`, or `both`. This unlocks the driving use case — syncing a
+user's IPv6 address into a UniFi **Network List** of type `ipv6-address-group`
+— without inventing per-provider type names, and gives every current and future
+provider the same knob.
+
+```yaml
+resources:
+  - cloud: unifi
+    type: networklist
+    name: usenetstreamer-allow-list-ipv4   # ip_version omitted => ipv4
+
+  - cloud: unifi
+    type: networklist
+    ip_version: ipv6
+    name: usenetstreamer-allow-list-ipv6
+
+  - cloud: unifi
+    type: networklist
+    ip_version: both
+    name: mixed-example
+```
+
+Along the way this fixes two pre-existing IPv6 defects found while designing
+(see **Defects absorbed**).
+
+## Motivation
+
+`user.finishUser()` already stores an IPv6 client correctly — `addNetmask()`
+gives it a `/128` and it goes into Redis like any other address. But every
+resource then discards it: all six Azure types guard with
+`isValidIpOrNetV4()`, and `UnifiNetworkList.buildMembers()` does the same. An
+IPv6-connecting user is silently whitelisted nowhere.
+
+UniFi firewall groups are family-typed (`address-group` vs
+`ipv6-address-group`), so an IPv6 Network List is a real, separate list that
+needs IPv6 members pushed to it.
+
+## Decisions
+
+Settled during brainstorming, recorded here because each rules out an
+alternative that looks reasonable in isolation:
+
+1. **A shared `ip_version` field, not new type names.** An earlier sketch used
+   `type: networklist-ipv4` / `networklist-ipv6`. A field applies uniformly to
+   all providers and does not multiply type names per family.
+
+2. **Default is `ipv4`.** Preserves today's behaviour on upgrade for every
+   resource type (see #3 for the one exception this required). `ipv6` and
+   `both` are opt-in.
+
+3. **Front Door defaults to `both`.** Front Door is the only resource type with
+   *no* family filter today (`azure.go:134` omits the `isValidIpOrNetV4` guard
+   the other five Azure types have), so it currently passes IPv6 through. A flat
+   `ipv4` default would silently stop whitelisting IPv6 users there. Defaulting
+   just this type to `both` makes the upgrade a true no-op for all seven types.
+
+4. **No capability table and no `group_type` verification.** `ip_version` is a
+   pure filter over the whitelist. Setting `ip_version: ipv6` on a resource
+   whose backing service is IPv4-only (Key Vault is documented IPv4-only) is
+   the operator's call, not something the app polices. `getFirewallGroup()`
+   continues to match on name alone.
+
+5. **One IP per user — no dual-stack capture.** `w.List` holds a single address
+   per user, whichever family their browser reached the app over. An
+   IPv4-connecting user therefore never appears in an IPv6 list. Capturing both
+   families would need a client-side probe and a Redis schema change; explicitly
+   out of scope.
+
+6. **`ip_version` is not added to per-file `Defaults`.** YAGNI; `Defaults`
+   stays `subscription_id` / `resource_group`.
+
+## Design
+
+### Config
+
+`ResourceConfiguration` gains one field:
+
+```go
+type ResourceConfiguration struct {
+	// ...
+	IPVersion string `yaml:"ip_version"` // ipv4 (default) | ipv6 | both
+}
+```
+
+`config.load()` lowercases the value and validates it against
+`{"", "ipv4", "ipv6", "both"}`, calling `log.Fatalln` on anything else — the
+same failure style already used for an unsupported `cloud` or `type`. Each of
+the seven `case` arms copies `resource.IPVersion` onto its resource struct; the
+Front Door arm substitutes `both` when the field is empty (decision #3).
+
+### The filter
+
+One helper in `functions.go` replaces `isValidIpOrNetV4` at all twelve call
+sites. `isValidIpOrNetV4` is deleted and its test converted.
+
+```go
+// matchesIpVersion reports whether ip is a parseable address of the family
+// selected by a resource's ip_version. An empty want means ipv4.
+func matchesIpVersion(want, ip string) bool {
+	t, err := ipVersion(ip)
+	if err != nil {
+		return false
+	}
+	switch want {
+	case "ipv6":
+		return t == IpV6
+	case "both":
+		return true
+	default:
+		return t == IpV4
+	}
+}
+```
+
+It keeps `isValidIpOrNetV4`'s existing contract for unparseable input —
+`ipVersion()` already logs and returns an error, and the helper returns false —
+so no caller gains a new failure mode.
+
+### Resource structs and call sites
+
+The six Azure structs and `UnifiNetworkList` each gain an `IPVersion string`
+field. Guards become `matchesIpVersion(nl.IPVersion, ip)`:
+
+| file | sites | change |
+|---|---|---|
+| `azure.go` | 10 | `isValidIpOrNetV4(x)` → `matchesIpVersion(<res>.IPVersion, x)` |
+| `azure.go:134` | 1 | Front Door — **add** the missing guard |
+| `unifi.go` | 2 | `buildMembers` dynamic + static loops |
+
+### UniFi member format
+
+`unifiMember()` strips `/128` alongside `/32`, by symmetry with the existing
+IPv4 reasoning (UniFi stores single hosts bare, and matching its stored form
+keeps `sameMembers()` stable so an unchanged whitelist doesn't force a PUT
+every reconcile).
+
+**Unverified against a live gateway.** This is the same open item already
+tracked for the `/32` behaviour and the `group_type` string values; it folds
+into the outstanding UniFi live-gateway validation task rather than blocking
+this work.
+
+## Defects absorbed
+
+Both are pre-existing, both are IPv6-specific, and both become reachable the
+moment `ip_version` can be set to `ipv6` or `both`.
+
+### 1. Front Door has no family filter
+
+`azure.go:134` is the only whitelist guard in the codebase without a family
+check. IPv6 addresses already flow into Front Door WAF custom rules today.
+Adding the guard (defaulted to `both`) makes the behaviour explicit and
+configurable without changing it.
+
+Note: Microsoft's docs confirm Key Vault is IPv4-only but state nothing either
+way about Front Door WAF `IPMatch` and IPv6. The existing code assumes IPv6
+works there; this design preserves that assumption rather than betting against
+it.
+
+### 2. `getIpList` silently corrupts IPv6
+
+`binary.BigEndian.Uint32(ipv4Net.Mask)` reads the first four bytes of what is a
+sixteen-byte mask for IPv6, and `Uint32(ipv4Net.IP)` the first four bytes of the
+address. No panic — just a wrong `first` and `last`, fed to StorageAccount,
+Postgres, RedisCache and CosmosDb.
+
+The fix is to **stop enumerating** rather than to extend enumeration to IPv6:
+
+- Nothing consumes the `all` return. All six Azure call sites are
+  `first, last, _ := getIpList(...)`; only `functions_test.go` reads it.
+- Enumeration cannot survive IPv6 — a `/64` is 1.8×10¹⁹ addresses — and is
+  already a latent problem for IPv4 (a `/8` allocates 16M strings).
+
+So `getIpList` is replaced by:
+
+```go
+// ipRange returns the first and last address of cidr. Works for IPv4 and IPv6;
+// a bare address is its own first and last.
+func ipRange(cidr string) (first, last string, err error)
+```
+
+computing the bounds by byte-wise mask math on `net.IPNet` (`ip[i] & mask[i]`
+and `ip[i] | ^mask[i]`), which is family-agnostic. The `log.Fatal` on an
+unparseable CIDR becomes a returned error — a bad config value should not take
+the process down mid-reconcile. Six call sites and `TestGetIpList` are updated.
+
+## Testing
+
+`matchesIpVersion` and `ipRange` are pure functions, so the meaningful coverage
+is cheap and needs neither Redis nor Docker.
+
+- **`functions_test.go`** — table test for `matchesIpVersion` across
+  `{ipv4, ipv6, both, ""}` × `{v4 bare, v4 CIDR, v6 bare, v6 CIDR, garbage}`.
+- **`functions_test.go`** — `ipRange` for a v4 CIDR (preserving the existing
+  expectations), a v6 CIDR, bare addresses of both families, and an
+  unparseable value returning an error rather than exiting.
+- **`config_test.go`** — `ip_version` parses and lowercases; empty defaults to
+  `ipv4`; empty on a Front Door resource defaults to `both`; an invalid value
+  is rejected.
+- **`unifi_test.go`** — extends the existing `buildMembers` tests behind the
+  `unifiClient` seam: an `ipv6` list excludes v4 members, `/128` is stripped,
+  and `both` keeps addresses of both families.
+
+Azure stays untested, per the existing decision recorded in the workspace notes
+(globals, no client seam; no provider-interface refactor before a third
+provider). Its behaviour here rides entirely on `matchesIpVersion` and
+`ipRange`, both of which are directly covered.
+
+## Documentation
+
+- `config/config.yaml` and `config.dev/config.yaml` — document `ip_version` on
+  the sample resources, including a UniFi IPv6 Network List example.
+- `README.md` — add `ip_version` to the resource field reference, noting the
+  `ipv4` default and the Front Door `both` exception.
+- `helm/ip-whitelister/README.md` — update if it documents resource fields.
+
+## Out of scope
+
+- Dual-stack capture of both families per user (decision #5).
+- Verifying a UniFi group's `group_type` against the configured `ip_version`
+  (decision #4).
+- Live-gateway validation of the `/128` member format — tracked with the
+  existing UniFi validation item.
+- Any Azure provider-interface refactor.

--- a/functions.go
+++ b/functions.go
@@ -72,6 +72,34 @@ func getIpList(cidr string) (first string, last string, all []string) {
 	return ret[0], ret[len(ret)-1], ret
 }
 
+// ipRange returns the first and last address of cidr. Bounds are computed with
+// byte-wise mask arithmetic, so it works for IPv4 and IPv6 alike — unlike
+// getIpList, which reads a 16-byte IPv6 mask as a uint32 and returns nonsense.
+// It deliberately does not enumerate the range: an IPv6 /64 holds 1.8e19
+// addresses, and no caller needs the full list. A bare address is its own first
+// and last. An unparseable value returns an error rather than exiting.
+func ipRange(cidr string) (first string, last string, err error) {
+	if !strings.Contains(cidr, "/") {
+		if _, err := ipVersion(cidr); err != nil {
+			return "", "", err
+		}
+		return cidr, cidr, nil
+	}
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", "", err
+	}
+
+	firstIP := make(net.IP, len(network.IP))
+	lastIP := make(net.IP, len(network.IP))
+	for i := range network.IP {
+		firstIP[i] = network.IP[i] & network.Mask[i]
+		lastIP[i] = network.IP[i] | ^network.Mask[i]
+	}
+	return firstIP.String(), lastIP.String(), nil
+}
+
 // function to check if any of the users groups are in the resources groups list
 func hasGroup(resourceGroups []string, userGroups []string) bool {
 	if resourceGroups == nil {

--- a/functions.go
+++ b/functions.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/binary"
 	"errors"
 	"log"
 	"net"
@@ -41,41 +40,9 @@ func chunkList(array []string, count int) [][]string {
 	return b
 }
 
-// function to get ips in subnet range
-func getIpList(cidr string) (first string, last string, all []string) {
-	var ret []string
-	if !strings.Contains(cidr, "/") {
-		// single ip
-		return cidr, cidr, []string{cidr}
-	}
-	// convert string to IPNet struct
-	_, ipv4Net, err := net.ParseCIDR(cidr)
-	if err != nil {
-		log.Fatal("functions.getIpList():", err)
-	}
-
-	// convert IPNet struct mask and address to uint32
-	// network is BigEndian
-	mask := binary.BigEndian.Uint32(ipv4Net.Mask)
-	start := binary.BigEndian.Uint32(ipv4Net.IP)
-
-	// find the final address
-	finish := (start & mask) | (mask ^ 0xffffffff)
-
-	// loop through addresses as uint32
-	for i := start; i <= finish; i++ {
-		// convert back to net.IP
-		ip := make(net.IP, 4)
-		binary.BigEndian.PutUint32(ip, i)
-		ret = append(ret, ip.String())
-	}
-	return ret[0], ret[len(ret)-1], ret
-}
-
 // ipRange returns the first and last address of cidr. Bounds are computed with
-// byte-wise mask arithmetic, so it works for IPv4 and IPv6 alike — unlike
-// getIpList, which reads a 16-byte IPv6 mask as a uint32 and returns nonsense.
-// It deliberately does not enumerate the range: an IPv6 /64 holds 1.8e19
+// byte-wise mask arithmetic, so it works for IPv4 and IPv6 alike. It
+// deliberately does not enumerate the range: an IPv6 /64 holds 1.8e19
 // addresses, and no caller needs the full list. A bare address is its own first
 // and last. An unparseable value returns an error rather than exiting.
 func ipRange(cidr string) (first string, last string, err error) {
@@ -115,17 +82,10 @@ func hasGroup(resourceGroups []string, userGroups []string) bool {
 	return false
 }
 
-// isValidIpOrNetV4 reports whether ip is a parseable IPv4 address or IPv4 CIDR.
-func isValidIpOrNetV4(ip string) bool {
-	ipType, err := ipVersion(ip)
-	return err == nil && ipType == IpV4
-}
-
 // matchesIpVersion reports whether ip is a parseable address (with or without a
 // netmask) of the address family selected by a resource's ip_version. An empty
 // want means ipv4, which is the default for every resource type except Front
-// Door. Unparseable input never matches, so this fully replaces the
-// isValidIpOrNetV4 guard it supersedes.
+// Door. Unparseable input never matches.
 func matchesIpVersion(want, ip string) bool {
 	t, err := ipVersion(ip)
 	if err != nil {

--- a/functions.go
+++ b/functions.go
@@ -16,6 +16,13 @@ const (
 	IpV6
 )
 
+// Supported values for a resource's ip_version field.
+const (
+	ipVersionV4   = "ipv4"
+	ipVersionV6   = "ipv6"
+	ipVersionBoth = "both"
+)
+
 // function to split an array of strings
 func chunkList(array []string, count int) [][]string {
 	lena := len(array)
@@ -84,6 +91,26 @@ func hasGroup(resourceGroups []string, userGroups []string) bool {
 func isValidIpOrNetV4(ip string) bool {
 	ipType, err := ipVersion(ip)
 	return err == nil && ipType == IpV4
+}
+
+// matchesIpVersion reports whether ip is a parseable address (with or without a
+// netmask) of the address family selected by a resource's ip_version. An empty
+// want means ipv4, which is the default for every resource type except Front
+// Door. Unparseable input never matches, so this fully replaces the
+// isValidIpOrNetV4 guard it supersedes.
+func matchesIpVersion(want, ip string) bool {
+	t, err := ipVersion(ip)
+	if err != nil {
+		return false
+	}
+	switch want {
+	case ipVersionV6:
+		return t == IpV6
+	case ipVersionBoth:
+		return true
+	default:
+		return t == IpV4
+	}
 }
 
 // ipVersion returns whether ip (with or without a netmask) is IPv4 or IPv6.

--- a/functions_test.go
+++ b/functions_test.go
@@ -32,7 +32,7 @@ func TestIpRange(t *testing.T) {
 		successFirst string
 		successLast  string
 	}{
-		// IPv4 — same expectations the old getIpList test asserted
+		// IPv4
 		{"10.0.0.0/31", "10.0.0.0", "10.0.0.1"},
 		{"200.0.0.0/30", "200.0.0.0", "200.0.0.3"},
 		{"10.0.0.1", "10.0.0.1", "10.0.0.1"},
@@ -61,7 +61,7 @@ func TestIpRange(t *testing.T) {
 }
 
 // TestIpRangeInvalid asserts a bad value returns an error rather than calling
-// log.Fatal and taking the process down mid-reconcile, as getIpList did.
+// log.Fatal and taking the process down mid-reconcile.
 func TestIpRangeInvalid(t *testing.T) {
 	for _, cidr := range []string{"not-an-ip", "10.0.0.0/99", "10.0.0.0/", ""} {
 		if _, _, err := ipRange(cidr); err == nil {

--- a/functions_test.go
+++ b/functions_test.go
@@ -103,6 +103,49 @@ func TestIsValidIpOrNetV4(t *testing.T) {
 	}
 }
 
+func TestMatchesIpVersion(t *testing.T) {
+	tests := []struct {
+		want    string
+		ip      string
+		success bool
+	}{
+		// empty want behaves as ipv4, preserving the old isValidIpOrNetV4 default
+		{"", "1.2.3.4", true},
+		{"", "1.2.3.0/24", true},
+		{"", "2a00:11c7:1234:b801::1", false},
+
+		{"ipv4", "1.2.3.4", true},
+		{"ipv4", "1.2.3.4/32", true},
+		{"ipv4", "1.2.3.0/24", true},
+		{"ipv4", "2a00:11c7:1234:b801::1", false},
+		{"ipv4", "2a00:11c7:1234:b801::/64", false},
+
+		{"ipv6", "2a00:11c7:1234:b801::1", true},
+		{"ipv6", "2a00:11c7:1234:b801::1/128", true},
+		{"ipv6", "2a00:11c7:1234:b801::/64", true},
+		{"ipv6", "1.2.3.4", false},
+		{"ipv6", "1.2.3.0/24", false},
+
+		{"both", "1.2.3.4", true},
+		{"both", "2a00:11c7:1234:b801::1", true},
+		{"both", "1.2.3.0/24", true},
+		{"both", "2a00:11c7:1234:b801::/64", true},
+
+		// unparseable input is never a match, whatever the family
+		{"ipv4", "not-an-ip", false},
+		{"ipv6", "not-an-ip", false},
+		{"both", "not-an-ip", false},
+		{"", "not-an-ip", false},
+	}
+
+	for _, f := range tests {
+		success := matchesIpVersion(f.want, f.ip)
+		if success != f.success {
+			t.Errorf("matchesIpVersion(%q, %q) = %v, want %v", f.want, f.ip, success, f.success)
+		}
+	}
+}
+
 func TestIpVersion(t *testing.T) {
 	tests := []struct {
 		ip      string

--- a/functions_test.go
+++ b/functions_test.go
@@ -53,6 +53,50 @@ func TestGetIpList(t *testing.T) {
 	}
 }
 
+func TestIpRange(t *testing.T) {
+	tests := []struct {
+		cidr         string
+		successFirst string
+		successLast  string
+	}{
+		// IPv4 — same expectations the old getIpList test asserted
+		{"10.0.0.0/31", "10.0.0.0", "10.0.0.1"},
+		{"200.0.0.0/30", "200.0.0.0", "200.0.0.3"},
+		{"10.0.0.1", "10.0.0.1", "10.0.0.1"},
+		{"1.2.3.4/32", "1.2.3.4", "1.2.3.4"},
+		{"10.0.0.0/24", "10.0.0.0", "10.0.0.255"},
+
+		// IPv6 — the family the old implementation silently corrupted
+		{"2a00:11c7:1234:b801::/64", "2a00:11c7:1234:b801::", "2a00:11c7:1234:b801:ffff:ffff:ffff:ffff"},
+		{"2a00:11c7:1234:b801::1/128", "2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+	}
+
+	for _, f := range tests {
+		first, last, err := ipRange(f.cidr)
+		if err != nil {
+			t.Errorf("ipRange(%q) returned unexpected error %v", f.cidr, err)
+			continue
+		}
+		if first != f.successFirst {
+			t.Errorf("ipRange(%q) first = %v, want %v", f.cidr, first, f.successFirst)
+		}
+		if last != f.successLast {
+			t.Errorf("ipRange(%q) last = %v, want %v", f.cidr, last, f.successLast)
+		}
+	}
+}
+
+// TestIpRangeInvalid asserts a bad value returns an error rather than calling
+// log.Fatal and taking the process down mid-reconcile, as getIpList did.
+func TestIpRangeInvalid(t *testing.T) {
+	for _, cidr := range []string{"not-an-ip", "10.0.0.0/99", "10.0.0.0/", ""} {
+		if _, _, err := ipRange(cidr); err == nil {
+			t.Errorf("ipRange(%q) should return an error", cidr)
+		}
+	}
+}
+
 func TestHasGroup(t *testing.T) {
 
 	groups := []struct {

--- a/functions_test.go
+++ b/functions_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -25,32 +24,6 @@ func TestChunkList(t *testing.T) {
 		}
 	}
 
-}
-
-func TestGetIpList(t *testing.T) {
-	tests := []struct {
-		cidr         string
-		successFirst string
-		successLast  string
-		successAll   []string
-	}{
-		{"10.0.0.0/31", "10.0.0.0", "10.0.0.1", []string{"10.0.0.0", "10.0.0.1"}},
-		{"200.0.0.0/30", "200.0.0.0", "200.0.0.3", []string{"200.0.0.0", "200.0.0.1", "200.0.0.2", "200.0.0.3"}},
-		{"10.0.0.1", "10.0.0.1", "10.0.0.1", []string{"10.0.0.1"}},
-	}
-
-	for _, f := range tests {
-		first, last, all := getIpList(f.cidr)
-		if first != f.successFirst {
-			t.Errorf("getIpList for %v was incorrect, got %v, want %v", f, first, f.successFirst)
-		}
-		if last != f.successLast {
-			t.Errorf("getIpList for %v was incorrect, got %v, want %v", f, last, f.successLast)
-		}
-		if !reflect.DeepEqual(all, f.successAll) {
-			t.Errorf("getIpList for %v was incorrect, got %v, want %v", f, all, f.successAll)
-		}
-	}
 }
 
 func TestIpRange(t *testing.T) {
@@ -125,35 +98,14 @@ func TestHasGroup(t *testing.T) {
 
 }
 
-func TestIsValidIpOrNetV4(t *testing.T) {
-	tests := []struct {
-		ip      string
-		success bool
-	}{
-		{"12.12.12.12/32", true},
-		{"1.2.3.4/32", true},
-		{"1.2.3.4", true},
-		{"1.2.3.0/24", true},
-		{"2a00:11c7:1234:b801:a16e:12af:5e42:1100/32", false},
-		{"2a00:11c7:1234:b801:a16e:12af:5e42:1111", false},
-		{"not-an-ip", false},
-	}
-
-	for _, f := range tests {
-		success := isValidIpOrNetV4(f.ip)
-		if success != f.success {
-			t.Errorf("isValidIpOrNetV4 for %v was incorrect, got %v, want %v", f, success, f.success)
-		}
-	}
-}
-
 func TestMatchesIpVersion(t *testing.T) {
 	tests := []struct {
 		want    string
 		ip      string
 		success bool
 	}{
-		// empty want behaves as ipv4, preserving the old isValidIpOrNetV4 default
+		// an empty want behaves as ipv4, which is the default for every
+		// resource type except Front Door
 		{"", "1.2.3.4", true},
 		{"", "1.2.3.0/24", true},
 		{"", "2a00:11c7:1234:b801::1", false},

--- a/unifi.go
+++ b/unifi.go
@@ -24,6 +24,7 @@ type UnifiNetworkList struct {
 	Name        string   // the Network List / firewall group name
 	Group       []string // optional AzureAD group filter
 	IPWhiteList []string // optional per-list static entries
+	IPVersion   string   // ipv4 (default) | ipv6 | both
 	client      unifiClient
 }
 
@@ -219,7 +220,7 @@ func (nl *UnifiNetworkList) buildMembers(list map[string]string, getGroups func(
 	}
 	// dynamic whitelist
 	for key, ip := range list {
-		if !w.inRange(ip, nl.IPWhiteList) && isValidIpOrNetV4(ip) {
+		if !w.inRange(ip, nl.IPWhiteList) && matchesIpVersion(nl.IPVersion, ip) {
 			if hasGroup(nl.Group, getGroups(key)) {
 				add(ip)
 			} else if c.Debug {
@@ -229,7 +230,7 @@ func (nl *UnifiNetworkList) buildMembers(list map[string]string, getGroups func(
 	}
 	// static whitelist (global + per-list)
 	for _, ip := range append(c.IPWhiteList, nl.IPWhiteList...) {
-		if isValidIpOrNetV4(ip) {
+		if matchesIpVersion(nl.IPVersion, ip) {
 			add(ip)
 		}
 	}
@@ -237,11 +238,21 @@ func (nl *UnifiNetworkList) buildMembers(list map[string]string, getGroups func(
 }
 
 // unifiMember formats an address for a UniFi firewall group. UniFi stores single
-// hosts as bare IPs — its UI rejects a /32 suffix ("enter single host addresses
-// without the subnet mask") — so we strip a /32 while leaving real subnets (e.g.
-// /24) untouched. Matching UniFi's stored form also keeps sameMembers() stable,
-// so an unchanged whitelist doesn't force a PUT on every reconcile.
+// hosts as bare IPs — its UI rejects a host netmask ("enter single host
+// addresses without the subnet mask") — so we strip the single-host mask while
+// leaving real subnets (e.g. /24) untouched. Matching UniFi's stored form also
+// keeps sameMembers() stable, so an unchanged whitelist doesn't force a PUT on
+// every reconcile. The host mask is family-dependent: /32 for IPv4, /128 for
+// IPv6. On IPv6 a /32 is a large subnet and must be preserved, so the family
+// must be resolved before trimming.
 func unifiMember(ip string) string {
+	t, err := ipVersion(ip)
+	if err != nil {
+		return ip
+	}
+	if t == IpV6 {
+		return strings.TrimSuffix(ip, "/128")
+	}
 	return strings.TrimSuffix(ip, "/32")
 }
 

--- a/unifi_test.go
+++ b/unifi_test.go
@@ -165,6 +165,102 @@ func TestBuildMembersDeduplicates(t *testing.T) {
 	}
 }
 
+// TestUnifiMemberFamilyAware asserts single hosts lose their mask while real
+// subnets keep theirs — including the trap that /32 is a host mask on IPv4 but a
+// large subnet on IPv6.
+func TestUnifiMemberFamilyAware(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want string
+	}{
+		{"1.1.1.1/32", "1.1.1.1"},
+		{"1.1.1.1", "1.1.1.1"},
+		{"85.0.0.0/24", "85.0.0.0/24"},
+		{"2a00:11c7:1234:b801::1/128", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::1", "2a00:11c7:1234:b801::1"},
+		{"2a00:11c7:1234:b801::/64", "2a00:11c7:1234:b801::/64"},
+		// /32 on IPv6 is a subnet, not a host — it must survive untouched
+		{"2a00:11c7::/32", "2a00:11c7::/32"},
+		// unparseable input is passed through unchanged
+		{"not-an-ip", "not-an-ip"},
+	}
+
+	for _, f := range tests {
+		if got := unifiMember(f.ip); got != f.want {
+			t.Errorf("unifiMember(%q) = %q, want %q", f.ip, got, f.want)
+		}
+	}
+}
+
+func TestBuildMembersIPv6(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = []string{"9.9.9.9/32", "2a00:1111::5/128"} // one of each family
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "v6", Group: nil, IPVersion: ipVersionV6}
+	list := map[string]string{
+		"alice": "1.1.1.1/32",                 // IPv4 -> excluded from a v6 list
+		"bob":   "2a00:2222:3333:4444::1/128", // IPv6 -> included, mask stripped
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	want := map[string]bool{
+		"2a00:2222:3333:4444::1": true, // bob, host mask stripped
+		"2a00:1111::5":           true, // static v6 host, mask stripped
+	}
+	if len(got) != len(want) {
+		t.Fatalf("buildMembers = %v, want keys %v", got, want)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected member %q in %v (v6 list must exclude IPv4)", m, got)
+		}
+	}
+}
+
+func TestBuildMembersBothFamilies(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = nil
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "mixed", Group: nil, IPVersion: ipVersionBoth}
+	list := map[string]string{
+		"alice": "1.1.1.1/32",
+		"bob":   "2a00:2222::1/128",
+		"bad":   "not-an-ip",
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	want := map[string]bool{"1.1.1.1": true, "2a00:2222::1": true}
+	if len(got) != len(want) {
+		t.Fatalf("buildMembers = %v, want keys %v", got, want)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected member %q in %v", m, got)
+		}
+	}
+}
+
+// TestBuildMembersDefaultsToIPv4 pins the upgrade guarantee: a list with no
+// ip_version set behaves exactly as it did before this field existed.
+func TestBuildMembersDefaultsToIPv4(t *testing.T) {
+	c.Debug = false
+	c.IPWhiteList = nil
+	getGroups := func(string) []string { return nil }
+	nl := UnifiNetworkList{Name: "legacy", Group: nil} // IPVersion zero value
+	list := map[string]string{
+		"alice": "1.1.1.1/32",
+		"bob":   "2a00:2222::1/128",
+	}
+
+	got := nl.buildMembers(list, getGroups)
+
+	if len(got) != 1 || got[0] != "1.1.1.1" {
+		t.Errorf("buildMembers = %v, want [1.1.1.1] (unset ip_version means ipv4)", got)
+	}
+}
+
 type fakeUnifiClient struct {
 	group       unifiFirewallGroup
 	getErr      error


### PR DESCRIPTION
## Summary

Adds a provider-agnostic `ip_version` field to every resource — `ipv4` (default), `ipv6`, or `both` — so a user's IPv6 address can be synced into a UniFi `ipv6-address-group` Network List. `user.finishUser()` already stored IPv6 clients correctly as `/128`; every resource then discarded them via a hardcoded `isValidIpOrNetV4` guard.

```yaml
resources:
  - cloud: unifi
    type: networklist
    name: ip-whitelister-ipv6
    ip_version: ipv6
```

Two pre-existing IPv6 defects are fixed along the way:

- **Front Door had no address-family filter at all.** It was the only whitelist guard without one, so IPv6 addresses already flowed into its WAF custom rules. It now has the guard, defaulted to `both` so behaviour is unchanged.
- **`getIpList` silently corrupted IPv6.** `binary.BigEndian.Uint32(ipv4Net.Mask)` read the first 4 bytes of a 16-byte mask — no panic, just wrong bounds fed to Storage Account, Postgres, Redis and Cosmos DB. Replaced by `ipRange`, which computes bounds with byte-wise mask arithmetic and does not enumerate the range (an IPv6 `/64` is 1.8e19 addresses; even a v4 `/8` allocated 16M strings). Its `log.Fatal` became a returned error.

Upgrade is a no-op: every resource type keeps its current behaviour under the defaults.

Design: `docs/superpowers/specs/2026-08-24-ip-version-ipv6-design.md`
Plan: `docs/superpowers/plans/2026-08-24-ip-version-ipv6.md`

## Notes

- A user has one whitelisted IP — whichever family their browser reached the app over — so an IPv4 user never appears in an `ipv6` resource. Dual-stack capture was considered and deliberately left out of scope.
- UniFi host masks are family-dependent: `/32` for IPv4, `/128` for IPv6. `unifiMember` resolves the family before trimming, since `/32` on IPv6 is a large subnet that must be preserved.
- `ip_version` filters what the app sends; it does not check what the backing service accepts (Azure Key Vault firewall rules are documented IPv4-only).
- The `/128` member format and UniFi's `ipv6-address-group` handling remain unverified against a live gateway — same open item already tracked for the `/32` behaviour.

## Test Plan

- [x] `go test -count=1 ./...` passes (66s, includes the Docker-backed Redis suite)
- [x] `go build ./... && go vet ./...` clean, `gofmt -l .` empty
- [x] New coverage: `matchesIpVersion` (4 wants x 5 input shapes), `ipRange` (v4 + v6 + invalid), `resolveIpVersion`, `ip_version` YAML unmarshalling, UniFi IPv6/both/default-v4 member building, family-aware `unifiMember`
- [x] Pre-existing `TestBuildMembers*` still pass unchanged, pinning the ipv4 default
- [ ] Live-gateway check of an IPv6 Network List

🤖 Generated with [Claude Code](https://claude.com/claude-code)