### PR TITLE
feat: dual-stack ip resolution (ip_resolution config block)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -127,16 +127,60 @@ entry is keyed on the identity the proxy supplies in the configured `header`
 (default `Cf-Access-Authenticated-User-Email`); if that header is absent the
 entry is keyed on the client IP instead.
 
-The client IP is read from the `ip_header` request header (default
-`Cf-Connecting-Ip`, which Cloudflare sets). **Your proxy MUST set this header to
-the real client IP and strip any client-supplied value** — otherwise an
+The client IP is read from the header named by `ip_resolution` (see below).
+`auth.ip_header` is **deprecated** but still honoured as a fallback for any
+family that names no header of its own. **Your proxy MUST set this header to the
+real client IP and strip any client-supplied value** — otherwise an
 authenticated user could spoof it to whitelist an arbitrary address. For Azure
-Front Door use `ip_header: X-Azure-Clientip`.
+Front Door use `X-Azure-Clientip`.
 
 Because AzureAD group membership is unavailable without OAuth, **group-scoped
 resources are skipped** in this mode — only resources without a `group:` filter
 are whitelisted. `tenant_id`, `client_id` and `client_secret` are ignored and
 can be omitted.
+
+### Dual-stack (`ip_resolution`)
+
+A request only reveals the address family the browser connected over, so a
+dual-stack user is normally whitelisted for one family only — in practice IPv6,
+which browsers prefer. `ip_resolution` describes how to learn an address for
+each family:
+
+```yaml
+ip_resolution:
+  ipv4:
+    enabled: true                     # default true
+    header: Cf-Connecting-Ip          # trusted client-IP header
+    url: https://ipv4.icanhazip.com   # optional, see below
+    url_timeout: 5s                   # optional, default 5s
+  ipv6:
+    enabled: true
+    header: Cf-Connecting-Ip
+    url: https://ipv6.icanhazip.com
+    url_timeout: 5s
+```
+
+Omitting the block entirely reproduces the previous behaviour: both families are
+enabled, and whichever family the browser connected over is recorded. Each
+family gets its own Redis entry and its own TTL, so one expiring does not
+disturb the other.
+
+This controls what the app **collects**. A resource's `ip_version` controls
+where it is **sent** — the two are independent, and an IPv6 address still only
+reaches resources configured for `ipv6` or `both`.
+
+**`header` is trusted; `url` is not.** A header value is observed by the app or
+its proxy and cannot be forged. A `url` is a family-pinned echo service fetched
+**by the browser**, whose answer is POSTed back to `/resolve` — so the address
+arrives as a *claim*. An authenticated user can fabricate it and whitelist an
+address they do not control. Setting `url` is the opt-in to that trade-off; the
+app logs which families use it at startup. Where the app can see the address
+itself, the observed value always wins over the claim.
+
+The echo service must send `Access-Control-Allow-Origin` or the browser will
+refuse to read the response; `icanhazip.com` does. Note that it will learn your
+hostname (via the `Origin` header) and the user's IP. No cookies or auth headers
+are sent to it.
 
 ### UniFi
 

--- a/config.go
+++ b/config.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"gopkg.in/yaml.v2"
@@ -123,6 +125,140 @@ func mustResolveIpVersion(v, def string) string {
 		log.Fatalln("config.load(): unsupported ip_version '" + v + "' (expected ipv4, ipv6 or both)")
 	}
 	return out
+}
+
+// IpResolution describes, per address family, how the app learns a user's
+// address. It governs what we COLLECT; a resource's ip_version governs where we
+// SEND it. The two are orthogonal.
+type IpResolution struct {
+	IPv4 IpFamilyResolution `yaml:"ipv4"`
+	IPv6 IpFamilyResolution `yaml:"ipv6"`
+}
+
+// IpFamilyResolution is one family's settings. Enabled is a pointer because
+// Go's zero value for bool is false, which would make an omitted block
+// indistinguishable from an explicitly disabled one and silently disable
+// whitelisting for every existing config.
+type IpFamilyResolution struct {
+	Enabled    *bool  `yaml:"enabled"`
+	Header     string `yaml:"header"`
+	Url        string `yaml:"url"`
+	UrlTimeout string `yaml:"url_timeout"`
+
+	// resolved from UrlTimeout by resolveIpResolution. yaml.v2 cannot unmarshal
+	// "5s" into a time.Duration — it only maps integers, as nanoseconds — so the
+	// config field stays a string and is parsed here.
+	timeoutDur time.Duration
+}
+
+const defaultUrlTimeout = 5 * time.Second
+const defaultIpHeader = "X-Azure-Clientip"
+
+// isEnabled reports whether this family may be whitelisted. An unset Enabled
+// means true.
+func (f IpFamilyResolution) isEnabled() bool {
+	return f.Enabled == nil || *f.Enabled
+}
+
+// timeout is how long the browser may spend fetching Url.
+func (f IpFamilyResolution) timeout() time.Duration {
+	if f.timeoutDur <= 0 {
+		return defaultUrlTimeout
+	}
+	return f.timeoutDur
+}
+
+// family returns the settings and IpType for a named address family.
+func (ir IpResolution) family(name string) (IpFamilyResolution, IpType, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case ipVersionV4:
+		return ir.IPv4, IpV4, true
+	case ipVersionV6:
+		return ir.IPv6, IpV6, true
+	}
+	return IpFamilyResolution{}, Undefined, false
+}
+
+// enabledFor reports whether addresses of family t may be whitelisted.
+func (ir IpResolution) enabledFor(t IpType) bool {
+	if t == IpV6 {
+		return ir.IPv6.isEnabled()
+	}
+	return ir.IPv4.isEnabled()
+}
+
+// headers returns the distinct client-IP header names to try, ipv4 first. It
+// falls back to the deprecated auth.ip_header and then the Front Door default,
+// so it behaves correctly even when config.load() has not run (as in tests).
+func (ir IpResolution) headers() []string {
+	out := []string{}
+	for _, h := range []string{ir.IPv4.Header, ir.IPv6.Header} {
+		if h == "" {
+			continue
+		}
+		dup := false
+		for _, e := range out {
+			if e == h {
+				dup = true
+			}
+		}
+		if !dup {
+			out = append(out, h)
+		}
+	}
+	if len(out) == 0 {
+		if c.Auth.IPHeader != "" {
+			return []string{c.Auth.IPHeader}
+		}
+		return []string{defaultIpHeader}
+	}
+	return out
+}
+
+// resolveIpResolution validates the ip_resolution block and fills in derived
+// values: the header fallback chain and the parsed url_timeout. authIpHeader is
+// the deprecated auth.ip_header. It returns an error rather than exiting so it
+// can be tested; load() wraps it with a fatal, matching mustResolveIpVersion.
+func resolveIpResolution(ir IpResolution, authIpHeader string) (IpResolution, error) {
+	if !ir.IPv4.isEnabled() && !ir.IPv6.isEnabled() {
+		return ir, errors.New("ip_resolution: both ipv4 and ipv6 are disabled, nothing could ever be whitelisted")
+	}
+
+	families := []struct {
+		name string
+		fr   *IpFamilyResolution
+	}{
+		{ipVersionV4, &ir.IPv4},
+		{ipVersionV6, &ir.IPv6},
+	}
+
+	for _, f := range families {
+		if f.fr.Header == "" {
+			f.fr.Header = authIpHeader
+		}
+		if f.fr.Header == "" {
+			f.fr.Header = defaultIpHeader
+		}
+
+		if f.fr.Url != "" && !f.fr.isEnabled() {
+			return ir, errors.New("ip_resolution." + f.name + ": url is set on a disabled family")
+		}
+		if f.fr.UrlTimeout != "" {
+			if f.fr.Url == "" {
+				return ir, errors.New("ip_resolution." + f.name + ": url_timeout is set without url")
+			}
+			d, err := time.ParseDuration(f.fr.UrlTimeout)
+			if err != nil {
+				return ir, errors.New("ip_resolution." + f.name + ": invalid url_timeout '" + f.fr.UrlTimeout + "'")
+			}
+			if d <= 0 {
+				return ir, errors.New("ip_resolution." + f.name + ": url_timeout must be positive, got '" + f.fr.UrlTimeout + "'")
+			}
+			f.fr.timeoutDur = d
+		}
+	}
+
+	return ir, nil
 }
 
 // applyAuthDefaults fills in auth defaults. When auth is disabled

--- a/config.go
+++ b/config.go
@@ -24,6 +24,8 @@ type Configuration struct {
 	IPWhiteList []string                `yaml:"ip_whitelist"`
 	TTL         int                     `yaml:"ttl"`
 	Unifi       UnifiConfiguration      `yaml:"unifi"`
+	// IpResolution controls which address families are collected and how.
+	IpResolution IpResolution `yaml:"ip_resolution"`
 }
 
 // Defaults are per-config-file fallback values applied to any resource in that
@@ -309,7 +311,31 @@ func (c *Configuration) load(reload ...bool) *Configuration {
 		c.TTL = 24
 	}
 
+	// captured before applyAuthDefaults, which sets IPHeader for auth.type none
+	// — warning afterwards would fire for configs that never set the field
+	deprecatedIpHeader := c.Auth.IPHeader
+
 	c.Auth = applyAuthDefaults(c.Auth)
+
+	if deprecatedIpHeader != "" {
+		log.Println("config.load(): WARNING auth.ip_header is deprecated, use ip_resolution.<family>.header instead")
+	}
+
+	ipResolution, err := resolveIpResolution(c.IpResolution, c.Auth.IPHeader)
+	if err != nil {
+		log.Fatalln("config.load(): " + err.Error())
+	}
+	c.IpResolution = ipResolution
+
+	// client-asserted resolution weakens the trust model: the address arrives as
+	// a claim rather than something the app observed. Setting url is the opt-in,
+	// so record it in the log rather than behind a config flag.
+	if c.IpResolution.IPv4.Url != "" {
+		log.Println("config.load(): ipv4 uses client-asserted resolution via " + c.IpResolution.IPv4.Url)
+	}
+	if c.IpResolution.IPv6.Url != "" {
+		log.Println("config.load(): ipv6 uses client-asserted resolution via " + c.IpResolution.IPv6.Url)
+	}
 
 	if c.Unifi.Site == "" {
 		c.Unifi.Site = "default"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -87,17 +87,11 @@ resources:
       - 52.187.184.26
   - cloud: unifi
     type: networklist
-    name: ip-whitelister # the UniFi Network List to keep in sync
-  # ip_version selects which address family a resource is whitelisted for:
-  #   ipv4 (default) | ipv6 | both
-  # Without an ip_resolution url, a user only has whichever family their
-  # browser reached the app over.
-  # Note: azure frontdoor defaults to both, since it has never filtered by family.
-  # A UniFi Network List is family-typed, so IPv6 needs its own list.
+    name: ip-whitelister
   - cloud: unifi
     type: networklist
     name: ip-whitelister-ipv6
-    ip_version: ipv6
+    ip_version: ipv6 # ipv4 (default) | ipv6
 
 # This whitelist will be applied to all resources and should be static non-human IPs only
 ip_whitelist:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,20 +8,8 @@ url: http://localhost:8080
 # User whitelistings will expire/be removed after 24 hours
 ttl: 24 # hours
 
-# How the app learns a user's address, per family. This controls what we
-# COLLECT; a resource's ip_version controls where we SEND it.
-#
-# Both families default to enabled. Omitting this block entirely reproduces the
-# previous behaviour: whichever family the browser connected over is recorded.
-#
-# header — a trusted client-IP header set by your proxy. The value is something
-#   the app observed, so it cannot be forged by the user.
-# url — a family-pinned echo service fetched BY THE BROWSER, letting a
-#   dual-stack user register both addresses in one visit. The address arrives as
-#   a claim the app cannot verify, so an authenticated user could whitelist an
-#   address they do not control. Setting url is the opt-in to that trade-off.
-# url_timeout — how long the browser may spend on that fetch (default 5s).
-#
+# How a user's address is collected, per family (see README).
+# url is fetched by the browser, so its answer is client-asserted.
 # ip_resolution:
 #   ipv4:
 #     enabled: true
@@ -102,9 +90,8 @@ resources:
     name: ip-whitelister # the UniFi Network List to keep in sync
   # ip_version selects which address family a resource is whitelisted for:
   #   ipv4 (default) | ipv6 | both
-  # A user has one address per family. Without ip_resolution urls configured
-  # they only have whichever family their browser reached the app over, so an
-  # IPv4-only user never appears in an ipv6 resource.
+  # Without an ip_resolution url, a user only has whichever family their
+  # browser reached the app over.
   # Note: azure frontdoor defaults to both, since it has never filtered by family.
   # A UniFi Network List is family-typed, so IPv6 needs its own list.
   - cloud: unifi

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,32 @@ url: http://localhost:8080
 # User whitelistings will expire/be removed after 24 hours
 ttl: 24 # hours
 
+# How the app learns a user's address, per family. This controls what we
+# COLLECT; a resource's ip_version controls where we SEND it.
+#
+# Both families default to enabled. Omitting this block entirely reproduces the
+# previous behaviour: whichever family the browser connected over is recorded.
+#
+# header — a trusted client-IP header set by your proxy. The value is something
+#   the app observed, so it cannot be forged by the user.
+# url — a family-pinned echo service fetched BY THE BROWSER, letting a
+#   dual-stack user register both addresses in one visit. The address arrives as
+#   a claim the app cannot verify, so an authenticated user could whitelist an
+#   address they do not control. Setting url is the opt-in to that trade-off.
+# url_timeout — how long the browser may spend on that fetch (default 5s).
+#
+# ip_resolution:
+#   ipv4:
+#     enabled: true
+#     header: Cf-Connecting-Ip
+#     url: https://ipv4.icanhazip.com
+#     url_timeout: 5s
+#   ipv6:
+#     enabled: true
+#     header: Cf-Connecting-Ip
+#     url: https://ipv6.icanhazip.com
+#     url_timeout: 5s
+
 auth:
   type: azure
   tenant_id: notreal-not-real-not-notreal
@@ -76,8 +102,9 @@ resources:
     name: ip-whitelister # the UniFi Network List to keep in sync
   # ip_version selects which address family a resource is whitelisted for:
   #   ipv4 (default) | ipv6 | both
-  # A user has one IP — whichever family their browser reached the app over — so
-  # an IPv4 user never appears in an ipv6 resource, and vice versa.
+  # A user has one address per family. Without ip_resolution urls configured
+  # they only have whichever family their browser reached the app over, so an
+  # IPv4-only user never appears in an ipv6 resource.
   # Note: azure frontdoor defaults to both, since it has never filtered by family.
   # A UniFi Network List is family-typed, so IPv6 needs its own list.
   - cloud: unifi

--- a/config_test.go
+++ b/config_test.go
@@ -176,6 +176,22 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadIpResolutionDefaults(t *testing.T) {
+	ret := c.load()
+
+	// the sample config has no ip_resolution block, so both families must come
+	// out enabled with a usable header — today's behaviour, unchanged
+	if !ret.IpResolution.IPv4.isEnabled() || !ret.IpResolution.IPv6.isEnabled() {
+		t.Error("both families should be enabled when the block is omitted")
+	}
+	if ret.IpResolution.IPv4.Header == "" || ret.IpResolution.IPv6.Header == "" {
+		t.Errorf("headers should be populated, got %q / %q", ret.IpResolution.IPv4.Header, ret.IpResolution.IPv6.Header)
+	}
+	if len(ret.IpResolution.headers()) == 0 {
+		t.Error("headers() should never be empty")
+	}
+}
+
 func TestLoadResourceConfigsMissingDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "does-not-exist")
 

--- a/config_test.go
+++ b/config_test.go
@@ -4,7 +4,149 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestIsEnabledDefaultsToTrue(t *testing.T) {
+	// the zero value must mean enabled: config.load() is never called in most
+	// tests, and an omitted block must not disable whitelisting
+	if !(IpFamilyResolution{}).isEnabled() {
+		t.Error("zero-value IpFamilyResolution should be enabled")
+	}
+	if !(IpFamilyResolution{Enabled: boolPtr(true)}).isEnabled() {
+		t.Error("explicit true should be enabled")
+	}
+	if (IpFamilyResolution{Enabled: boolPtr(false)}).isEnabled() {
+		t.Error("explicit false should be disabled")
+	}
+}
+
+func TestResolveIpResolutionDefaults(t *testing.T) {
+	got, err := resolveIpResolution(IpResolution{}, "")
+	if err != nil {
+		t.Fatalf("empty block should be valid, got: %v", err)
+	}
+	if !got.IPv4.isEnabled() || !got.IPv6.isEnabled() {
+		t.Error("both families should default to enabled")
+	}
+	if got.IPv4.Header != "X-Azure-Clientip" || got.IPv6.Header != "X-Azure-Clientip" {
+		t.Errorf("headers should default to X-Azure-Clientip, got %q / %q", got.IPv4.Header, got.IPv6.Header)
+	}
+	if got.IPv4.timeout() != defaultUrlTimeout {
+		t.Errorf("timeout = %v, want %v", got.IPv4.timeout(), defaultUrlTimeout)
+	}
+}
+
+func TestResolveIpResolutionDeprecatedAuthHeader(t *testing.T) {
+	// auth.ip_header still fills in for a family that names no header of its own
+	got, err := resolveIpResolution(IpResolution{}, "Cf-Connecting-Ip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.Header != "Cf-Connecting-Ip" || got.IPv6.Header != "Cf-Connecting-Ip" {
+		t.Errorf("auth.ip_header not used as fallback, got %q / %q", got.IPv4.Header, got.IPv6.Header)
+	}
+
+	// an explicit per-family header wins over the deprecated field
+	got, err = resolveIpResolution(IpResolution{IPv4: IpFamilyResolution{Header: "X-Own"}}, "Cf-Connecting-Ip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.Header != "X-Own" {
+		t.Errorf("explicit header should win, got %q", got.IPv4.Header)
+	}
+	if got.IPv6.Header != "Cf-Connecting-Ip" {
+		t.Errorf("other family should still fall back, got %q", got.IPv6.Header)
+	}
+}
+
+func TestResolveIpResolutionTimeout(t *testing.T) {
+	got, err := resolveIpResolution(IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "2s"},
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.timeout() != 2*time.Second {
+		t.Errorf("timeout = %v, want 2s", got.IPv4.timeout())
+	}
+	// a url with no explicit timeout falls back to the default
+	if got.IPv6.timeout() != defaultUrlTimeout {
+		t.Errorf("unset timeout = %v, want %v", got.IPv6.timeout(), defaultUrlTimeout)
+	}
+}
+
+func TestResolveIpResolutionErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   IpResolution
+	}{
+		{
+			"both families disabled",
+			IpResolution{
+				IPv4: IpFamilyResolution{Enabled: boolPtr(false)},
+				IPv6: IpFamilyResolution{Enabled: boolPtr(false)},
+			},
+		},
+		{
+			"url on a disabled family",
+			IpResolution{
+				IPv6: IpFamilyResolution{Enabled: boolPtr(false), Url: "https://ipv6.icanhazip.com"},
+			},
+		},
+		{
+			"url_timeout without url",
+			IpResolution{IPv4: IpFamilyResolution{UrlTimeout: "5s"}},
+		},
+		{
+			"unparseable url_timeout",
+			IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "soon"}},
+		},
+		{
+			"non-positive url_timeout",
+			IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "0s"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := resolveIpResolution(tc.in, ""); err == nil {
+				t.Errorf("expected an error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestIpResolutionFamily(t *testing.T) {
+	ir := IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://v4.example.com"},
+		IPv6: IpFamilyResolution{Url: "https://v6.example.com"},
+	}
+
+	fr, ipType, ok := ir.family("ipv4")
+	if !ok || ipType != IpV4 || fr.Url != "https://v4.example.com" {
+		t.Errorf("family(ipv4) = %+v, %v, %v", fr, ipType, ok)
+	}
+	// normalised like ip_version is
+	if _, _, ok := ir.family("  IPv6  "); !ok {
+		t.Error("family() should normalise case and whitespace")
+	}
+	if _, _, ok := ir.family("ipv5"); ok {
+		t.Error("family(ipv5) should not be ok")
+	}
+}
+
+func TestIpResolutionEnabledFor(t *testing.T) {
+	ir := IpResolution{IPv6: IpFamilyResolution{Enabled: boolPtr(false)}}
+	if !ir.enabledFor(IpV4) {
+		t.Error("ipv4 should be enabled")
+	}
+	if ir.enabledFor(IpV6) {
+		t.Error("ipv6 should be disabled")
+	}
+}
 
 func TestLoad(t *testing.T) {
 	ret := c.load()

--- a/docs/superpowers/plans/2026-08-24-dual-stack-ip-resolution.md
+++ b/docs/superpowers/plans/2026-08-24-dual-stack-ip-resolution.md
@@ -1,0 +1,1593 @@
+# Dual-stack IP Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one user hold both an IPv4 and an IPv6 whitelist entry at the same time, captured via a new `ip_resolution` config block and stored under family-suffixed Redis keys.
+
+**Architecture:** Two independent halves. **Storage** — Redis DB0 gains a `:v6` key suffix so an IPv6 entry no longer overwrites the same user's IPv4 entry; providers are untouched because `r.getGroups()` normalises the suffix away and PR #8's `matchesIpVersion` guards already route entries by family. **Capture** — a new `ip_resolution` block describes per family how to learn an address (trusted proxy header / connection, and/or a browser-side fetch to a family-pinned echo service), with claims posted back to a new `/resolve` endpoint.
+
+**Tech Stack:** Go 1.x, flat `package main` at repo root. `gopkg.in/yaml.v2` for config, `gomodule/redigo` for Redis, `html/template` for pages, `ory/dockertest` for Redis-backed tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md`
+
+**Branch:** `feat/dual-stack-ip-resolution` (already created; spec already committed)
+
+---
+
+## File Structure
+
+| File | Responsibility after this plan |
+|------|-------------------------------|
+| `functions.go` | Pure helpers. Gains `redisKey` / `baseKey`. |
+| `redis.go` | Redis I/O. `getGroups` normalises the family suffix. |
+| `whitelist.go` | `add()` becomes family-aware and enforces `ip_resolution` enablement. |
+| `config.go` | `IpResolution` / `IpFamilyResolution` types, validation, `auth.ip_header` deprecation. |
+| `user.go` | `observedIp()` — resolution order for the address the app sees. |
+| `http.go` | `/resolve` handler, `pendingProbes()`, probe JS in both templates. |
+| `config/config.yaml`, `README.md` | Documentation. |
+
+Tests live beside their subject in the existing `*_test.go` files. **Tests touching Redis need Docker and are slow (~66s suite);** pure-logic tests go in `functions_test.go` / `config_test.go`, which need neither.
+
+Notes that affect several tasks:
+
+- Globals are declared in `main.go:3-10`: `c Configuration`, `r RedisConfiguration`, `h Authentication`, `w Whitelist`, `a Azure`, `u Unifi`. Inside `user.go` methods, `u` is the `*User` receiver and shadows the `Unifi` global — do not add code referring to the Unifi global inside a `User` method.
+- `config.load()` is never called by most tests, so every new type must behave correctly at its Go zero value. A `nil` `Enabled` pointer must mean *enabled*.
+
+---
+
+## Task 1: Family-suffixed Redis key helpers
+
+**Files:**
+- Modify: `functions.go`
+- Test: `functions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `functions_test.go`:
+
+```go
+func TestRedisKey(t *testing.T) {
+	tests := []struct {
+		base string
+		t    IpType
+		want string
+	}{
+		// ipv4 keeps the bare user key, so existing entries need no migration
+		{"alecpinson123456", IpV4, "alecpinson123456"},
+		{"alecpinson123456", IpV6, "alecpinson123456:v6"},
+		// an unknown family is treated as ipv4 rather than inventing a third key
+		{"alecpinson123456", Undefined, "alecpinson123456"},
+		// auth.type none derives the key from the ip itself; the regex strip in
+		// finishUser leaves only [a-z0-9], so ':' can never collide
+		{"2a001", IpV6, "2a001:v6"},
+	}
+
+	for _, f := range tests {
+		if got := redisKey(f.base, f.t); got != f.want {
+			t.Errorf("redisKey(%q, %v) = %q, want %q", f.base, f.t, got, f.want)
+		}
+	}
+}
+
+func TestBaseKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"alecpinson123456", "alecpinson123456"},
+		{"alecpinson123456:v6", "alecpinson123456"},
+		{"2a001:v6", "2a001"},
+		// only a trailing suffix is stripped
+		{"alec:v6user", "alec:v6user"},
+	}
+
+	for _, f := range tests {
+		if got := baseKey(f.in); got != f.want {
+			t.Errorf("baseKey(%q) = %q, want %q", f.in, got, f.want)
+		}
+	}
+}
+
+func TestRedisKeyRoundTrip(t *testing.T) {
+	for _, base := range []string{"alecpinson123456", "2a001", "a"} {
+		for _, ipType := range []IpType{IpV4, IpV6} {
+			if got := baseKey(redisKey(base, ipType)); got != base {
+				t.Errorf("baseKey(redisKey(%q, %v)) = %q, want %q", base, ipType, got, base)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestRedisKey|TestBaseKey' -v .`
+Expected: FAIL — `undefined: redisKey`, `undefined: baseKey`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `functions.go`:
+
+```go
+// redisKeySuffixV6 distinguishes a user's IPv6 whitelist entry from their IPv4
+// one in Redis DB0. IPv4 keeps the bare user key so entries written before
+// dual-stack support need no migration. A user key is [a-z0-9]+ after the regex
+// strip in finishUser, so ':' can never collide with a generated key.
+const redisKeySuffixV6 = ":v6"
+
+// redisKey returns the DB0 key holding this user's address for family t.
+func redisKey(base string, t IpType) string {
+	if t == IpV6 {
+		return base + redisKeySuffixV6
+	}
+	return base
+}
+
+// baseKey strips any family suffix, returning the plain user key used by the
+// groups cache (DB1) and the API throttle (DB2), both of which are per user
+// rather than per address family.
+func baseKey(k string) string {
+	return strings.TrimSuffix(k, redisKeySuffixV6)
+}
+```
+
+`strings` is already imported in `functions.go:7`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestRedisKey|TestBaseKey' -v .`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions.go functions_test.go
+git commit -m "feat: add family-suffixed redis key helpers"
+```
+
+---
+
+## Task 2: Normalise the family suffix in getGroups
+
+This is what keeps all seven providers unchanged: they call `r.getGroups(key)` with whatever key they read out of `w.List`, which may now carry a `:v6` suffix, while the groups cache is keyed per user.
+
+**Files:**
+- Modify: `redis.go:181-210`
+- Test: `redis_test.go` (needs Docker — slow)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `redis_test.go`:
+
+```go
+func TestGetGroupsIgnoresFamilySuffix(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if r.connect(rc) {
+		const user = "testuser111111"
+		if !r.addGroups(user, []string{"group1", "group2"}) {
+			t.Fatal("failed to seed groups")
+		}
+
+		// providers read keys straight out of w.List, which now contains
+		// family-suffixed entries; both forms must find the same cached groups
+		if got := r.getGroups(user); len(got) != 2 {
+			t.Errorf("getGroups(%q) = %v, want 2 groups", user, got)
+		}
+		if got := r.getGroups(user + redisKeySuffixV6); len(got) != 2 {
+			t.Errorf("getGroups(%q) = %v, want 2 groups", user+redisKeySuffixV6, got)
+		}
+	}
+
+	DeleteTestRedis(t, testRedisInstance)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestGetGroupsIgnoresFamilySuffix -v .`
+Expected: FAIL — the suffixed lookup returns 0 groups
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `redis.go`, change the opening of `getGroups` (line 181) from:
+
+```go
+func (r RedisConfiguration) getGroups(user string) []string {
+	var g []string
+```
+
+to:
+
+```go
+func (r RedisConfiguration) getGroups(user string) []string {
+	// w.List keys carry a family suffix, but the groups cache is per user —
+	// normalising here is what lets every provider stay unchanged.
+	user = baseKey(user)
+
+	var g []string
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestGetGroupsIgnoresFamilySuffix -v .`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redis.go redis_test.go
+git commit -m "feat: normalise family suffix in redis getGroups"
+```
+
+---
+
+## Task 3: Config types for `ip_resolution`
+
+Validation is split into a testable `resolveIpResolution` returning an error plus a fatal wrapper, mirroring the existing `resolveIpVersion` / `mustResolveIpVersion` pair at `config.go:102-126`.
+
+**Files:**
+- Modify: `config.go`
+- Test: `config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `config_test.go`:
+
+```go
+func boolPtr(b bool) *bool { return &b }
+
+func TestIsEnabledDefaultsToTrue(t *testing.T) {
+	// the zero value must mean enabled: config.load() is never called in most
+	// tests, and an omitted block must not disable whitelisting
+	if !(IpFamilyResolution{}).isEnabled() {
+		t.Error("zero-value IpFamilyResolution should be enabled")
+	}
+	if !(IpFamilyResolution{Enabled: boolPtr(true)}).isEnabled() {
+		t.Error("explicit true should be enabled")
+	}
+	if (IpFamilyResolution{Enabled: boolPtr(false)}).isEnabled() {
+		t.Error("explicit false should be disabled")
+	}
+}
+
+func TestResolveIpResolutionDefaults(t *testing.T) {
+	got, err := resolveIpResolution(IpResolution{}, "")
+	if err != nil {
+		t.Fatalf("empty block should be valid, got: %v", err)
+	}
+	if !got.IPv4.isEnabled() || !got.IPv6.isEnabled() {
+		t.Error("both families should default to enabled")
+	}
+	if got.IPv4.Header != "X-Azure-Clientip" || got.IPv6.Header != "X-Azure-Clientip" {
+		t.Errorf("headers should default to X-Azure-Clientip, got %q / %q", got.IPv4.Header, got.IPv6.Header)
+	}
+	if got.IPv4.timeout() != defaultUrlTimeout {
+		t.Errorf("timeout = %v, want %v", got.IPv4.timeout(), defaultUrlTimeout)
+	}
+}
+
+func TestResolveIpResolutionDeprecatedAuthHeader(t *testing.T) {
+	// auth.ip_header still fills in for a family that names no header of its own
+	got, err := resolveIpResolution(IpResolution{}, "Cf-Connecting-Ip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.Header != "Cf-Connecting-Ip" || got.IPv6.Header != "Cf-Connecting-Ip" {
+		t.Errorf("auth.ip_header not used as fallback, got %q / %q", got.IPv4.Header, got.IPv6.Header)
+	}
+
+	// an explicit per-family header wins over the deprecated field
+	got, err = resolveIpResolution(IpResolution{IPv4: IpFamilyResolution{Header: "X-Own"}}, "Cf-Connecting-Ip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.Header != "X-Own" {
+		t.Errorf("explicit header should win, got %q", got.IPv4.Header)
+	}
+	if got.IPv6.Header != "Cf-Connecting-Ip" {
+		t.Errorf("other family should still fall back, got %q", got.IPv6.Header)
+	}
+}
+
+func TestResolveIpResolutionTimeout(t *testing.T) {
+	got, err := resolveIpResolution(IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "2s"},
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IPv4.timeout() != 2*time.Second {
+		t.Errorf("timeout = %v, want 2s", got.IPv4.timeout())
+	}
+	// a url with no explicit timeout falls back to the default
+	if got.IPv6.timeout() != defaultUrlTimeout {
+		t.Errorf("unset timeout = %v, want %v", got.IPv6.timeout(), defaultUrlTimeout)
+	}
+}
+
+func TestResolveIpResolutionErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   IpResolution
+	}{
+		{
+			"both families disabled",
+			IpResolution{
+				IPv4: IpFamilyResolution{Enabled: boolPtr(false)},
+				IPv6: IpFamilyResolution{Enabled: boolPtr(false)},
+			},
+		},
+		{
+			"url on a disabled family",
+			IpResolution{
+				IPv6: IpFamilyResolution{Enabled: boolPtr(false), Url: "https://ipv6.icanhazip.com"},
+			},
+		},
+		{
+			"url_timeout without url",
+			IpResolution{IPv4: IpFamilyResolution{UrlTimeout: "5s"}},
+		},
+		{
+			"unparseable url_timeout",
+			IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "soon"}},
+		},
+		{
+			"non-positive url_timeout",
+			IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com", UrlTimeout: "0s"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := resolveIpResolution(tc.in, ""); err == nil {
+				t.Errorf("expected an error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestIpResolutionFamily(t *testing.T) {
+	ir := IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://v4.example.com"},
+		IPv6: IpFamilyResolution{Url: "https://v6.example.com"},
+	}
+
+	fr, ipType, ok := ir.family("ipv4")
+	if !ok || ipType != IpV4 || fr.Url != "https://v4.example.com" {
+		t.Errorf("family(ipv4) = %+v, %v, %v", fr, ipType, ok)
+	}
+	// normalised like ip_version is
+	if _, _, ok := ir.family("  IPv6  "); !ok {
+		t.Error("family() should normalise case and whitespace")
+	}
+	if _, _, ok := ir.family("ipv5"); ok {
+		t.Error("family(ipv5) should not be ok")
+	}
+}
+
+func TestIpResolutionEnabledFor(t *testing.T) {
+	ir := IpResolution{IPv6: IpFamilyResolution{Enabled: boolPtr(false)}}
+	if !ir.enabledFor(IpV4) {
+		t.Error("ipv4 should be enabled")
+	}
+	if ir.enabledFor(IpV6) {
+		t.Error("ipv6 should be disabled")
+	}
+}
+```
+
+Add `"time"` to the imports of `config_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestIsEnabled|TestResolveIpResolution|TestIpResolution' -v .`
+Expected: FAIL — `undefined: IpFamilyResolution`, `undefined: resolveIpResolution`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `"errors"` and `"time"` to the imports of `config.go`, then append these types and functions:
+
+```go
+// IpResolution describes, per address family, how the app learns a user's
+// address. It governs what we COLLECT; a resource's ip_version governs where we
+// SEND it. The two are orthogonal.
+type IpResolution struct {
+	IPv4 IpFamilyResolution `yaml:"ipv4"`
+	IPv6 IpFamilyResolution `yaml:"ipv6"`
+}
+
+// IpFamilyResolution is one family's settings. Enabled is a pointer because
+// Go's zero value for bool is false, which would make an omitted block
+// indistinguishable from an explicitly disabled one and silently disable
+// whitelisting for every existing config.
+type IpFamilyResolution struct {
+	Enabled    *bool  `yaml:"enabled"`
+	Header     string `yaml:"header"`
+	Url        string `yaml:"url"`
+	UrlTimeout string `yaml:"url_timeout"`
+
+	// resolved from UrlTimeout by resolveIpResolution. yaml.v2 cannot unmarshal
+	// "5s" into a time.Duration — it only maps integers, as nanoseconds — so the
+	// config field stays a string and is parsed here.
+	timeoutDur time.Duration
+}
+
+const defaultUrlTimeout = 5 * time.Second
+const defaultIpHeader = "X-Azure-Clientip"
+
+// isEnabled reports whether this family may be whitelisted. An unset Enabled
+// means true.
+func (f IpFamilyResolution) isEnabled() bool {
+	return f.Enabled == nil || *f.Enabled
+}
+
+// timeout is how long the browser may spend fetching Url.
+func (f IpFamilyResolution) timeout() time.Duration {
+	if f.timeoutDur <= 0 {
+		return defaultUrlTimeout
+	}
+	return f.timeoutDur
+}
+
+// family returns the settings and IpType for a named address family.
+func (ir IpResolution) family(name string) (IpFamilyResolution, IpType, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case ipVersionV4:
+		return ir.IPv4, IpV4, true
+	case ipVersionV6:
+		return ir.IPv6, IpV6, true
+	}
+	return IpFamilyResolution{}, Undefined, false
+}
+
+// enabledFor reports whether addresses of family t may be whitelisted.
+func (ir IpResolution) enabledFor(t IpType) bool {
+	if t == IpV6 {
+		return ir.IPv6.isEnabled()
+	}
+	return ir.IPv4.isEnabled()
+}
+
+// headers returns the distinct client-IP header names to try, ipv4 first. It
+// falls back to the deprecated auth.ip_header and then the Front Door default,
+// so it behaves correctly even when config.load() has not run (as in tests).
+func (ir IpResolution) headers() []string {
+	out := []string{}
+	for _, h := range []string{ir.IPv4.Header, ir.IPv6.Header} {
+		if h == "" {
+			continue
+		}
+		dup := false
+		for _, e := range out {
+			if e == h {
+				dup = true
+			}
+		}
+		if !dup {
+			out = append(out, h)
+		}
+	}
+	if len(out) == 0 {
+		if c.Auth.IPHeader != "" {
+			return []string{c.Auth.IPHeader}
+		}
+		return []string{defaultIpHeader}
+	}
+	return out
+}
+
+// resolveIpResolution validates the ip_resolution block and fills in derived
+// values: the header fallback chain and the parsed url_timeout. authIpHeader is
+// the deprecated auth.ip_header. It returns an error rather than exiting so it
+// can be tested; load() wraps it with a fatal, matching mustResolveIpVersion.
+func resolveIpResolution(ir IpResolution, authIpHeader string) (IpResolution, error) {
+	if !ir.IPv4.isEnabled() && !ir.IPv6.isEnabled() {
+		return ir, errors.New("ip_resolution: both ipv4 and ipv6 are disabled, nothing could ever be whitelisted")
+	}
+
+	families := []struct {
+		name string
+		fr   *IpFamilyResolution
+	}{
+		{ipVersionV4, &ir.IPv4},
+		{ipVersionV6, &ir.IPv6},
+	}
+
+	for _, f := range families {
+		if f.fr.Header == "" {
+			f.fr.Header = authIpHeader
+		}
+		if f.fr.Header == "" {
+			f.fr.Header = defaultIpHeader
+		}
+
+		if f.fr.Url != "" && !f.fr.isEnabled() {
+			return ir, errors.New("ip_resolution." + f.name + ": url is set on a disabled family")
+		}
+		if f.fr.UrlTimeout != "" {
+			if f.fr.Url == "" {
+				return ir, errors.New("ip_resolution." + f.name + ": url_timeout is set without url")
+			}
+			d, err := time.ParseDuration(f.fr.UrlTimeout)
+			if err != nil {
+				return ir, errors.New("ip_resolution." + f.name + ": invalid url_timeout '" + f.fr.UrlTimeout + "'")
+			}
+			if d <= 0 {
+				return ir, errors.New("ip_resolution." + f.name + ": url_timeout must be positive, got '" + f.fr.UrlTimeout + "'")
+			}
+			f.fr.timeoutDur = d
+		}
+	}
+
+	return ir, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestIsEnabled|TestResolveIpResolution|TestIpResolution' -v .`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config.go config_test.go
+git commit -m "feat: add ip_resolution config types and validation"
+```
+
+---
+
+## Task 4: Wire `ip_resolution` into config.load()
+
+**Files:**
+- Modify: `config.go:14-25` (struct field), `config.go:176` (load wiring)
+- Test: `config_test.go`
+
+The deprecation warning must read the **raw** `auth.ip_header`, captured before `applyAuthDefaults` runs — that function sets `IPHeader` to `Cf-Connecting-Ip` for every `auth.type: none` config (`config.go:137-139`), so warning afterwards would fire for users who never set the field.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `config_test.go`:
+
+```go
+func TestLoadIpResolutionDefaults(t *testing.T) {
+	ret := c.load()
+
+	// the sample config has no ip_resolution block, so both families must come
+	// out enabled with a usable header — today's behaviour, unchanged
+	if !ret.IpResolution.IPv4.isEnabled() || !ret.IpResolution.IPv6.isEnabled() {
+		t.Error("both families should be enabled when the block is omitted")
+	}
+	if ret.IpResolution.IPv4.Header == "" || ret.IpResolution.IPv6.Header == "" {
+		t.Errorf("headers should be populated, got %q / %q", ret.IpResolution.IPv4.Header, ret.IpResolution.IPv6.Header)
+	}
+	if len(ret.IpResolution.headers()) == 0 {
+		t.Error("headers() should never be empty")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestLoadIpResolutionDefaults -v .`
+Expected: FAIL — `ret.IpResolution undefined`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `config.go`, add the field to `Configuration` (after `Unifi` on line 24):
+
+```go
+	Unifi        UnifiConfiguration      `yaml:"unifi"`
+	IpResolution IpResolution            `yaml:"ip_resolution"`
+```
+
+Then replace `config.go:176`:
+
+```go
+	c.Auth = applyAuthDefaults(c.Auth)
+```
+
+with:
+
+```go
+	// captured before applyAuthDefaults, which sets IPHeader for auth.type none
+	// — warning afterwards would fire for configs that never set the field
+	deprecatedIpHeader := c.Auth.IPHeader
+
+	c.Auth = applyAuthDefaults(c.Auth)
+
+	if deprecatedIpHeader != "" {
+		log.Println("config.load(): WARNING auth.ip_header is deprecated, use ip_resolution.<family>.header instead")
+	}
+
+	ipResolution, err := resolveIpResolution(c.IpResolution, c.Auth.IPHeader)
+	if err != nil {
+		log.Fatalln("config.load(): " + err.Error())
+	}
+	c.IpResolution = ipResolution
+
+	// client-asserted resolution weakens the trust model: the address arrives as
+	// a claim rather than something the app observed. Setting url is the opt-in,
+	// so record it in the log rather than behind a config flag.
+	if c.IpResolution.IPv4.Url != "" {
+		log.Println("config.load(): ipv4 uses client-asserted resolution via " + c.IpResolution.IPv4.Url)
+	}
+	if c.IpResolution.IPv6.Url != "" {
+		log.Println("config.load(): ipv6 uses client-asserted resolution via " + c.IpResolution.IPv6.Url)
+	}
+```
+
+`err` is already in scope from `load()` line 163; `ipResolution, err := ...` is still valid because `ipResolution` is new.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestLoad|TestUnifiConfigLoad' -v .`
+Expected: PASS — including the pre-existing `TestLoad` and `TestUnifiConfigLoad`, which must not regress
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config.go config_test.go
+git commit -m "feat: wire ip_resolution into config load with ip_header deprecation"
+```
+
+---
+
+## Task 5: Resolution order in observedIp
+
+**Files:**
+- Modify: `user.go:103-144`
+- Test: `user_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `user_test.go`:
+
+```go
+func TestObservedIp(t *testing.T) {
+	defer func() { c.IpResolution = IpResolution{}; c.Auth.IPHeader = "" }()
+
+	// a per-family header is read
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+	if got := observedIp(req); got != "203.0.113.7" {
+		t.Errorf("observedIp() = %q, want %q", got, "203.0.113.7")
+	}
+
+	// the two families may name different headers; both are tried, ipv4 first
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "X-V4-Ip"},
+		IPv6: IpFamilyResolution{Header: "X-V6-Ip"},
+	}
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-V6-Ip", "2a00:11c7:1234:b801::1")
+	if got := observedIp(req); got != "2a00:11c7:1234:b801::1" {
+		t.Errorf("observedIp() = %q, want the ipv6 header value", got)
+	}
+
+	// with no header present, fall back to RemoteAddr
+	c.IpResolution = IpResolution{}
+	req = httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "198.51.100.9:54321"
+	if got := observedIp(req); got != "198.51.100.9" {
+		t.Errorf("observedIp() = %q, want %q", got, "198.51.100.9")
+	}
+
+	// the deprecated auth.ip_header still works when no family names one
+	c.IpResolution = IpResolution{}
+	c.Auth.IPHeader = "X-Legacy-Ip"
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Legacy-Ip", "203.0.113.8")
+	if got := observedIp(req); got != "203.0.113.8" {
+		t.Errorf("observedIp() = %q, want %q", got, "203.0.113.8")
+	}
+}
+```
+
+Ensure `user_test.go` imports `net/http/httptest` and `testing`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestObservedIp -v .`
+Expected: FAIL — `undefined: observedIp`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `user.go`, add above `finishUser`:
+
+```go
+// observedIp returns the client address as the app sees it: the first
+// ip_resolution header that is present, falling back to RemoteAddr. This is the
+// trusted path — the value is something the app or its proxy observed, not
+// something the client asserted.
+func observedIp(req *http.Request) string {
+	for _, header := range c.IpResolution.headers() {
+		if v := req.Header.Get(header); v != "" {
+			return v
+		}
+	}
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		log.Printf("user.observedIp(): %q is not IP:port\n", req.RemoteAddr)
+		return ""
+	}
+	return ip
+}
+```
+
+Then replace the header block in `finishUser` (`user.go:104-118`) with:
+
+```go
+	// the client IP as observed by the app or its trusted proxy
+	u.ip = observedIp(req)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestObservedIp|TestNoAuthIndexHandler' -v .`
+Expected: PASS — `TestNoAuthIndexHandler` (Docker, slow) must still pass, proving the deprecated `c.Auth.IPHeader` path still works
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user.go user_test.go
+git commit -m "feat: resolve observed client ip via ip_resolution headers"
+```
+
+---
+
+## Task 6: Family-aware whitelist.add()
+
+**Files:**
+- Modify: `whitelist.go:37-72`
+- Test: `whitelist_test.go` (needs Docker — slow)
+
+`addGroups`, `apiCalled` and `canCallApi` keep taking the **base** key: the groups cache and the API throttle are per user, not per family. Only `addIp` and `setIpExpiry` take the family key.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `whitelist_test.go`:
+
+```go
+func TestAddDualStack(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.IpResolution = IpResolution{}
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+
+	v4 := &User{key: "dualstackuser", ip: "203.0.113.7", cidr: "203.0.113.7/32"}
+	v6 := &User{key: "dualstackuser", ip: "2a00:11c7:1234:b801::1", cidr: "2a00:11c7:1234:b801::1/128"}
+
+	if !w.add(v4) {
+		t.Fatal("adding the ipv4 address failed")
+	}
+	if !w.add(v6) {
+		t.Fatal("adding the ipv6 address failed")
+	}
+
+	list := r.getWhitelist()
+	if got := list["dualstackuser"]; got != "203.0.113.7/32" {
+		t.Errorf("ipv4 entry = %q, want %q", got, "203.0.113.7/32")
+	}
+	if got := list["dualstackuser"+redisKeySuffixV6]; got != "2a00:11c7:1234:b801::1/128" {
+		t.Errorf("ipv6 entry = %q, want %q", got, "2a00:11c7:1234:b801::1/128")
+	}
+}
+
+func TestAddSkipsDisabledFamily(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	disabled := false
+	c.IpResolution = IpResolution{IPv6: IpFamilyResolution{Enabled: &disabled}}
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+
+	v6 := &User{key: "disabledfamilyuser", ip: "2a00:11c7:1234:b801::2", cidr: "2a00:11c7:1234:b801::2/128"}
+	if w.add(v6) {
+		t.Error("add() should refuse an address whose family is disabled")
+	}
+	if got := r.getWhitelist()["disabledfamilyuser"+redisKeySuffixV6]; got != "" {
+		t.Errorf("disabled family should not be stored, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestAddDualStack|TestAddSkipsDisabledFamily' -v .`
+Expected: FAIL — `TestAddDualStack` finds the v6 value under the bare key (the v4 entry was overwritten); `TestAddSkipsDisabledFamily` stores the address anyway
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `whitelist.go:37-72` with:
+
+```go
+func (w *Whitelist) add(u *User) bool {
+	w.List = r.getWhitelist()
+
+	if w.inRange(u.ip, c.IPWhiteList) {
+		return false
+	}
+
+	t, err := ipVersion(u.cidr)
+	if err != nil {
+		log.Printf("whitelist.add(): %v", err)
+		return false
+	}
+	if !c.IpResolution.enabledFor(t) {
+		log.Println("whitelist.add(): ip_resolution is disabled for this address family, skipping " + u.ip)
+		return false
+	}
+	// the groups cache and api throttle stay keyed per user; only the address
+	// itself is stored per family
+	key := redisKey(u.key, t)
+
+	ret := r.addGroups(u.key, u.groups)
+	if !ret {
+		return ret
+	}
+
+	if w.List[key] != u.cidr {
+		// need to update list
+		if w.List[key] == "" {
+			log.Println("whitelist.add(): no current whitelist for '" + key + "' was found, adding ip " + u.ip)
+		} else {
+			log.Println("whitelist.add(): updating whitelist for '" + key + "' from " + w.List[key] + " to " + u.ip)
+		}
+		ret = r.addIp(key, u.cidr)
+		if !ret {
+			return ret
+		}
+		r.apiCalled(u.key)
+		go w.updateResources()
+		return true
+	} else {
+		// ip already whitelisted ... renew redis expiry time though
+		log.Println("whitelist.add(): no changes required for '" + key + "', ip already set to " + u.ip)
+		if r.canCallApi(u.key) {
+			r.apiCalled(u.key)
+			go w.updateResources()
+		}
+		return r.setIpExpiry(key)
+	}
+}
+```
+
+Also update `delete` (`whitelist.go:74-82`) so it removes both families:
+
+```go
+func (w *Whitelist) delete(u *User) bool {
+	for _, t := range []IpType{IpV4, IpV6} {
+		if !r.deleteIp(redisKey(u.key, t)) {
+			return false
+		}
+	}
+	w.updateResources()
+	log.Println("whitelist.delete(): whitelisting for '" + u.key + "' removed.")
+	return true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestAdd|TestDelete' -v .`
+Expected: PASS — including the pre-existing `TestAdd` and `TestDelete`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add whitelist.go whitelist_test.go
+git commit -m "feat: make whitelist add and delete family-aware"
+```
+
+---
+
+## Task 7: The /resolve endpoint
+
+**Files:**
+- Modify: `http.go`
+- Test: `http_test.go` (needs Docker — slow)
+
+Two details that are easy to get wrong:
+
+1. `w.add()` calls `r.addGroups(u.key, u.groups)`. A `User` rebuilt for `/resolve` with `groups: nil` would **overwrite the cached groups with an empty list**, silently dropping the user out of every group-scoped resource. The rebuilt user must carry `r.getGroups(key)`.
+2. `callbackHandler` currently stores `name` and `ip_address` in the session but not `key`, and `/resolve` needs the key. Add it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `http_test.go`:
+
+```go
+func TestResolveHandler(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.Auth.Type = "none"
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv4.icanhazip.com"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv6.icanhazip.com"},
+	}
+	defer func() {
+		c.Auth.Type = ""
+		c.Auth.Header = ""
+		c.Auth.IPHeader = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	newReq := func(body string) *http.Request {
+		req := httptest.NewRequest("POST", "/resolve", strings.NewReader(body))
+		req.Header.Set("Cf-Access-Authenticated-User-Email", "bob@example.com")
+		req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+		return req
+	}
+
+	// a valid ipv6 claim from a request that arrived over ipv4 is accepted
+	rr := httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::1"}`)); err != nil {
+		t.Fatalf("resolveHandler() unexpected error: %v", err)
+	}
+	if got := r.getWhitelist()["bobexamplecom"+redisKeySuffixV6]; got != "2a00:11c7:1234:b801::1/128" {
+		t.Errorf("ipv6 entry = %q, want %q", got, "2a00:11c7:1234:b801::1/128")
+	}
+
+	// the claimed family must match the address actually supplied
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"198.51.100.9"}`)); err == nil {
+		t.Error("expected an error for a family mismatch")
+	}
+
+	// unparseable addresses are rejected. This must claim ipv6: the request
+	// arrives over ipv4, so an ipv4 claim would be replaced by the observed
+	// address before it was ever parsed.
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"not-an-ip"}`)); err == nil {
+		t.Error("expected an error for an unparseable ip")
+	}
+
+	// a claim for the family we observed is replaced by the observed address,
+	// which is trustworthy where the claim is not
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv4","ip":"8.8.8.8"}`)); err != nil {
+		t.Fatalf("resolveHandler() unexpected error: %v", err)
+	}
+	if got := r.getWhitelist()["bobexamplecom"]; got != "203.0.113.7/32" {
+		t.Errorf("ipv4 entry = %q, want the observed %q, not the claimed 8.8.8.8", got, "203.0.113.7/32")
+	}
+
+	// an unknown family is rejected
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv5","ip":"198.51.100.9"}`)); err == nil {
+		t.Error("expected an error for an unknown family")
+	}
+
+	// GET is not allowed
+	rr = httptest.NewRecorder()
+	getReq := httptest.NewRequest("GET", "/resolve", nil)
+	if err := resolveHandler(rr, getReq); err == nil {
+		t.Error("expected an error for a GET request")
+	}
+}
+
+func TestResolveHandlerRejectsUnconfiguredFamily(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.Auth.Type = "none"
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	// no url configured for ipv6 => the deployment never opted into
+	// client-asserted resolution, so /resolve must not act as an open
+	// whitelisting endpoint
+	c.IpResolution = IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"}}
+	defer func() {
+		c.Auth.Type = ""
+		c.Auth.Header = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("POST", "/resolve", strings.NewReader(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::9"}`))
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "carol@example.com")
+	rr := httptest.NewRecorder()
+
+	if err := resolveHandler(rr, req); err == nil {
+		t.Error("expected an error for a family with no url configured")
+	}
+	if got := r.getWhitelist()["carolexamplecom"+redisKeySuffixV6]; got != "" {
+		t.Errorf("unconfigured family should not be stored, got %q", got)
+	}
+}
+
+func TestResolveHandlerRejectsUnauthenticated(t *testing.T) {
+	// azure mode with no session token: /resolve must not whitelist anything
+	store = sessions.NewFilesystemStore(t.TempDir(), sessionStoreKeyPairs...)
+	c.Auth.Type = "azure"
+	c.IpResolution = IpResolution{IPv6: IpFamilyResolution{Url: "https://ipv6.icanhazip.com"}}
+	defer func() {
+		c.Auth.Type = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("POST", "/resolve", strings.NewReader(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::3"}`))
+	rr := httptest.NewRecorder()
+
+	err := resolveHandler(rr, req)
+	if err == nil {
+		t.Fatal("expected an error for an unauthenticated caller")
+	}
+	httpErr, ok := err.(Error)
+	if !ok || httpErr.Code != http.StatusUnauthorized {
+		t.Errorf("error = %v, want a 401", err)
+	}
+}
+```
+
+Ensure `http_test.go` imports `encoding/json` is **not** needed, but `strings` (already present at line 7) and `net/http` (line 5) are.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestResolveHandler -v .`
+Expected: FAIL — `undefined: resolveHandler`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `"encoding/json"` and `"io"` to the imports of `http.go`, then append:
+
+```go
+// resolveRequest is a client-asserted address for one family, POSTed by the
+// probe JS after it fetches the configured echo url.
+type resolveRequest struct {
+	Family string `json:"family"`
+	Ip     string `json:"ip"`
+}
+
+// resolveUser rebuilds the authenticated user for a /resolve request without
+// setting an address — the caller supplies that from the claim or the
+// connection. Groups are read back from the cache rather than left nil: w.add()
+// writes u.groups to the cache, so a nil slice here would silently drop the
+// user out of every group-scoped resource.
+func resolveUser(req *http.Request) (*User, error) {
+	switch strings.ToLower(c.Auth.Type) {
+	case "none", "disabled":
+		var u User
+		if u.newFromRequest(req) == nil {
+			return nil, Error{Code: http.StatusUnauthorized, Message: "could not determine client identity"}
+		}
+		return &u, nil
+	default:
+		session, _ := store.Get(req, "session")
+		if session.Values["token"] == nil {
+			return nil, Error{Code: http.StatusUnauthorized}
+		}
+		key, _ := session.Values["key"].(string)
+		if key == "" {
+			return nil, Error{Code: http.StatusUnauthorized}
+		}
+		name, _ := session.Values["name"].(string)
+		return &User{key: key, name: name, groups: r.getGroups(key)}, nil
+	}
+}
+
+// resolveHandler accepts a client-asserted address for one family and
+// whitelists it. The address is a claim the app cannot verify, so it is only
+// accepted for a family that has a url configured — otherwise a deployment that
+// never opted into client-asserted resolution would expose an open whitelisting
+// endpoint.
+func resolveHandler(wr http.ResponseWriter, req *http.Request) error {
+	if req.Method != http.MethodPost {
+		return Error{Code: http.StatusMethodNotAllowed}
+	}
+
+	var body resolveRequest
+	if err := json.NewDecoder(io.LimitReader(req.Body, 1024)).Decode(&body); err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "invalid json"}
+	}
+
+	fr, claimed, ok := c.IpResolution.family(body.Family)
+	if !ok {
+		return Error{Code: http.StatusBadRequest, Message: "unknown address family"}
+	}
+	if !fr.isEnabled() {
+		return Error{Code: http.StatusBadRequest, Message: "address family is disabled"}
+	}
+	if fr.Url == "" {
+		return Error{Code: http.StatusBadRequest, Message: "client-asserted resolution is not configured for this family"}
+	}
+
+	u, err := resolveUser(req)
+	if err != nil {
+		return err
+	}
+
+	ip := body.Ip
+	// if this request itself arrived over the claimed family, the address we
+	// observed is strictly better than the one being claimed
+	if observed := observedIp(req); observed != "" {
+		if t, err := ipVersion(observed); err == nil && t == claimed {
+			ip = observed
+		}
+	}
+
+	t, err := ipVersion(ip)
+	if err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "unparseable ip"}
+	}
+	if t != claimed {
+		return Error{Code: http.StatusBadRequest, Message: "ip does not match the claimed address family"}
+	}
+
+	cidr, err := addNetmask(ip)
+	if err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "unparseable ip"}
+	}
+	u.ip = ip
+	u.cidr = cidr
+	u.whitelist()
+
+	wr.WriteHeader(http.StatusNoContent)
+	return nil
+}
+```
+
+Register it in both auth modes. In `initAzure` (`http.go:180-184`) add before the `/` handler:
+
+```go
+	http.Handle("/resolve", handle(resolveHandler))
+```
+
+and the same line in `initNoAuth` (`http.go:205-208`).
+
+Finally, store the key in the session so the azure path can rebuild the user. In `callbackHandler`, after `session.Values["name"] = &u.name` (`http.go:242`), add:
+
+```go
+	session.Values["key"] = u.key
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestResolveHandler -v .`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add http.go http_test.go
+git commit -m "feat: add /resolve endpoint for client-asserted addresses"
+```
+
+---
+
+## Task 8: Probe JS in the page templates
+
+**Files:**
+- Modify: `http.go` (both templates, both index handlers)
+- Test: `http_test.go`
+
+`AbortSignal.timeout()` requires Chrome 103+ / Firefox 100+ / Safari 15.4+ (all 2022). `html/template` escapes `{{.Url}}` and `{{.Family}}` correctly for a JS string context and `{{.Timeout}}` for a JS numeric context — do not hand-quote them.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `http_test.go`:
+
+```go
+func TestPendingProbes(t *testing.T) {
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"},
+		IPv6: IpFamilyResolution{Url: "https://ipv6.icanhazip.com"},
+	}
+
+	// connected over ipv4 => only the ipv6 probe is pending
+	probes := pendingProbes("203.0.113.7")
+	if len(probes) != 1 || probes[0].Family != ipVersionV6 {
+		t.Errorf("pendingProbes(ipv4 client) = %+v, want one ipv6 probe", probes)
+	}
+	if probes[0].Timeout != int(defaultUrlTimeout/time.Millisecond) {
+		t.Errorf("timeout = %d ms, want %d ms", probes[0].Timeout, int(defaultUrlTimeout/time.Millisecond))
+	}
+
+	// connected over ipv6 => only the ipv4 probe is pending
+	probes = pendingProbes("2a00:11c7:1234:b801::1")
+	if len(probes) != 1 || probes[0].Family != ipVersionV4 {
+		t.Errorf("pendingProbes(ipv6 client) = %+v, want one ipv4 probe", probes)
+	}
+
+	// a family with no url is never probed
+	c.IpResolution = IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"}}
+	if probes := pendingProbes("203.0.113.7"); len(probes) != 0 {
+		t.Errorf("pendingProbes() = %+v, want none", probes)
+	}
+
+	// a disabled family is never probed
+	disabled := false
+	c.IpResolution = IpResolution{
+		IPv6: IpFamilyResolution{Enabled: &disabled, Url: ""},
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"},
+	}
+	if probes := pendingProbes("2a00:11c7:1234:b801::1"); len(probes) != 1 {
+		t.Errorf("pendingProbes() = %+v, want just the ipv4 probe", probes)
+	}
+}
+
+func TestNoAuthIndexHandlerRendersProbe(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv6.icanhazip.com"},
+	}
+	defer func() {
+		c.Auth.Header = ""
+		c.Auth.IPHeader = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "dave@example.com")
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+	rr := httptest.NewRecorder()
+
+	if err := noAuthIndexHandler(rr, req); err != nil {
+		t.Fatalf("noAuthIndexHandler() unexpected error: %v", err)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "ipv6.icanhazip.com") {
+		t.Errorf("body missing the ipv6 probe url:\n%s", body)
+	}
+	if !strings.Contains(body, "/resolve") {
+		t.Errorf("body missing the /resolve POST:\n%s", body)
+	}
+	// the ipv4 address came from the connection, so it must not be probed for
+	if strings.Contains(body, "ipv4.icanhazip.com") {
+		t.Errorf("body should not probe for the family already observed:\n%s", body)
+	}
+}
+```
+
+Add `"time"` to the imports of `http_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestPendingProbes|TestNoAuthIndexHandlerRendersProbe' -v .`
+Expected: FAIL — `undefined: pendingProbes`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `"time"` to the imports of `http.go`, then append:
+
+```go
+// probe is one family's browser-side lookup, rendered into the page.
+type probe struct {
+	Family  string
+	Url     string
+	Timeout int // milliseconds, for AbortSignal.timeout()
+}
+
+// pendingProbes returns the lookups the page should run: one per enabled family
+// that has a url configured and was not already satisfied by the connection.
+// The family we observed needs no probe, which also avoids a third-party
+// request for an address we already know.
+func pendingProbes(observed string) []probe {
+	observedType, err := ipVersion(observed)
+	if err != nil {
+		observedType = Undefined
+	}
+
+	var out []probe
+	families := []struct {
+		name string
+		t    IpType
+		fr   IpFamilyResolution
+	}{
+		{ipVersionV4, IpV4, c.IpResolution.IPv4},
+		{ipVersionV6, IpV6, c.IpResolution.IPv6},
+	}
+	for _, f := range families {
+		if !f.fr.isEnabled() || f.fr.Url == "" || f.t == observedType {
+			continue
+		}
+		out = append(out, probe{
+			Family:  f.name,
+			Url:     f.fr.Url,
+			Timeout: int(f.fr.timeout() / time.Millisecond),
+		})
+	}
+	return out
+}
+```
+
+Add this block to **both** templates, immediately before the closing `</body>` in `indexTempl` and `noAuthTempl`:
+
+```html
+{{range .Probes}}
+    <script>
+      (function () {
+        fetch({{.Url}}, {referrerPolicy: 'no-referrer', signal: AbortSignal.timeout({{.Timeout}})})
+          .then(function (res) { return res.ok ? res.text() : Promise.reject(res.status); })
+          .then(function (ip) {
+            return fetch('/resolve', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({family: {{.Family}}, ip: ip.trim()})
+            });
+          })
+          .catch(function (err) { console.log('ip probe failed', err); });
+      })();
+    </script>
+{{end}}
+```
+
+Add `Probes []probe` to both template data structs and populate them.
+
+In `noAuthIndexHandler` (`http.go:194-201`):
+
+```go
+	var data = struct {
+		Name      string
+		IPAddress string
+		Probes    []probe
+	}{
+		Name:      u.name,
+		IPAddress: u.ip,
+		Probes:    pendingProbes(u.ip),
+	}
+```
+
+In `IndexHandler` (`http.go:271-279`):
+
+```go
+	var probes []probe
+	if token != nil {
+		// before authentication the page only renders a redirect, so there is
+		// nothing to probe for yet
+		probes = pendingProbes(ipAddress)
+	}
+
+	var data = struct {
+		Token     *oauth2.Token
+		AuthURL   string
+		IPAddress string
+		Probes    []probe
+	}{
+		Token:     token,
+		AuthURL:   oauthConfig.AuthCodeURL(SessionState(session), oauth2.AccessTypeOnline),
+		IPAddress: ipAddress,
+		Probes:    probes,
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestPendingProbes|TestNoAuthIndexHandler|TestIndexHandler' -v .`
+Expected: PASS — including the pre-existing `TestIndexHandler`, `TestIndexHandlerWithToken` and `TestNoAuthIndexHandler`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add http.go http_test.go
+git commit -m "feat: render browser-side ip probes into the page templates"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `config/config.yaml`, `README.md`
+- Modify (local only): `config.dev/config.yaml`
+
+`config.dev/` is gitignored, so its edits never reach the PR — update it anyway so local `docker-compose.dev.yaml` runs exercise the new block.
+
+- [ ] **Step 1: Add the block to the sample config**
+
+In `config/config.yaml`, after the `ttl:` block (line 9), insert:
+
+```yaml
+# How the app learns a user's address, per family. This controls what we
+# COLLECT; a resource's ip_version controls where we SEND it.
+#
+# Both families default to enabled. Omitting this block entirely reproduces the
+# previous behaviour: whichever family the browser connected over is recorded.
+#
+# header — a trusted client-IP header set by your proxy. The value is something
+#   the app observed, so it cannot be forged by the user.
+# url — a family-pinned echo service fetched BY THE BROWSER, letting a
+#   dual-stack user register both addresses in one visit. The address arrives as
+#   a claim the app cannot verify, so an authenticated user could whitelist an
+#   address they do not control. Setting url is the opt-in to that trade-off.
+# url_timeout — how long the browser may spend on that fetch (default 5s).
+#
+# ip_resolution:
+#   ipv4:
+#     enabled: true
+#     header: Cf-Connecting-Ip
+#     url: https://ipv4.icanhazip.com
+#     url_timeout: 5s
+#   ipv6:
+#     enabled: true
+#     header: Cf-Connecting-Ip
+#     url: https://ipv6.icanhazip.com
+#     url_timeout: 5s
+```
+
+- [ ] **Step 2: Fix the now-false comment**
+
+`config/config.yaml:79-80` currently reads:
+
+```
+  # A user has one IP — whichever family their browser reached the app over — so
+  # an IPv4 user never appears in an ipv6 resource, and vice versa.
+```
+
+Replace those two lines with:
+
+```
+  # A user has one address per family. Without ip_resolution urls configured
+  # they only have whichever family their browser reached the app over, so an
+  # IPv4-only user never appears in an ipv6 resource.
+```
+
+- [ ] **Step 3: Update the README**
+
+In `README.md`, replace lines 130-134 (the paragraph beginning "The client IP is read from the `ip_header` request header") with:
+
+```markdown
+The client IP is read from the header named by `ip_resolution` (see below).
+`auth.ip_header` is **deprecated** but still honoured as a fallback for any
+family that names no header of its own. **Your proxy MUST set this header to the
+real client IP and strip any client-supplied value** — otherwise an
+authenticated user could spoof it to whitelist an arbitrary address. For Azure
+Front Door use `X-Azure-Clientip`.
+```
+
+Then add a new section immediately after the "Disabling auth" section (after line 139):
+
+```markdown
+### Dual-stack (`ip_resolution`)
+
+A request only reveals the address family the browser connected over, so a
+dual-stack user is normally whitelisted for one family only — in practice IPv6,
+which browsers prefer. `ip_resolution` describes how to learn an address for
+each family:
+
+```yaml
+ip_resolution:
+  ipv4:
+    enabled: true                     # default true
+    header: Cf-Connecting-Ip          # trusted client-IP header
+    url: https://ipv4.icanhazip.com   # optional, see below
+    url_timeout: 5s                   # optional, default 5s
+  ipv6:
+    enabled: true
+    header: Cf-Connecting-Ip
+    url: https://ipv6.icanhazip.com
+    url_timeout: 5s
+```
+
+Omitting the block entirely reproduces the previous behaviour: both families are
+enabled, and whichever family the browser connected over is recorded. Each
+family gets its own Redis entry and its own TTL, so one expiring does not
+disturb the other.
+
+This controls what the app **collects**. A resource's `ip_version` controls
+where it is **sent** — the two are independent, and an IPv6 address still only
+reaches resources configured for `ipv6` or `both`.
+
+**`header` is trusted; `url` is not.** A header value is observed by the app or
+its proxy and cannot be forged. A `url` is a family-pinned echo service fetched
+**by the browser**, whose answer is POSTed back to `/resolve` — so the address
+arrives as a *claim*. An authenticated user can fabricate it and whitelist an
+address they do not control. Setting `url` is the opt-in to that trade-off; the
+app logs which families use it at startup. Where the app can see the address
+itself, the observed value always wins over the claim.
+
+The echo service must send `Access-Control-Allow-Origin` or the browser will
+refuse to read the response; `icanhazip.com` does. Note that it will learn your
+hostname (via the `Origin` header) and the user's IP. No cookies or auth headers
+are sent to it.
+```
+
+- [ ] **Step 4: Mirror into the local dev config**
+
+Add the same `ip_resolution` block, uncommented and pointing at icanhazip, to `config.dev/config.yaml`.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `go test ./...`
+Expected: PASS (slow — the Redis-backed tests start Docker containers)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/config.yaml README.md
+git commit -m "docs: document ip_resolution and deprecate auth.ip_header"
+```
+
+---
+
+## Task 10: Full verification
+
+- [ ] **Step 1: Vet and build**
+
+Run: `go vet ./...`
+Expected: no output
+
+- [ ] **Step 2: Full test suite**
+
+Run: `go test ./...`
+Expected: `ok` — no failures
+
+- [ ] **Step 3: Confirm the Helm chart still renders**
+
+The chart passes `.Values.config` through verbatim, so no template change is needed — confirm nothing broke:
+
+Run: `helm lint helm/ip-whitelister`
+Expected: `1 chart(s) linted, 0 chart(s) failed`
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/dual-stack-ip-resolution
+```
+
+Do **not** open a PR without asking — `main` is branch-protected and requires a review.

--- a/docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md
@@ -1,0 +1,286 @@
+# Dual-stack IP resolution via an `ip_resolution` config block — design
+
+**Date:** 2026-08-24
+**Status:** Approved (design)
+**Author:** Alec Pinson
+
+## Summary
+
+Let a single user have **both** an IPv4 and an IPv6 address whitelisted at the
+same time, instead of only whichever family their browser happened to connect
+over.
+
+Two independent changes make that possible:
+
+1. **Capture** — a new top-level `ip_resolution` block describes, per address
+   family, how to learn the user's address: from a trusted proxy header / the
+   connection itself, and/or from a browser-side fetch to a family-pinned echo
+   service such as `ipv4.icanhazip.com`.
+2. **Storage** — Redis DB0 gains a family suffix so an IPv6 entry no longer
+   overwrites the same user's IPv4 entry.
+
+```yaml
+ip_resolution:
+  ipv4:
+    enabled: true
+    header: Cf-Connecting-Ip
+    url: https://ipv4.icanhazip.com
+  ipv6:
+    enabled: true
+    header: Cf-Connecting-Ip
+    url: https://ipv6.icanhazip.com
+```
+
+`ip_resolution` governs **what we collect**. The existing per-resource
+`ip_version` field (PR #8) governs **where we send it**. They are orthogonal and
+neither replaces the other.
+
+## Motivation
+
+`user.finishUser()` learns exactly one address: whatever arrives on the trusted
+header, falling back to `RemoteAddr`. That is a property of the connection, so a
+dual-stack user gets whichever family their browser preferred — in practice
+IPv6, since browsers prefer it under Happy Eyeballs.
+
+PR #8 made every resource family-aware, so an `ip_version: ipv4` resource
+correctly ignores an IPv6 user. The gap it deliberately left open is that such a
+user has **no** IPv4 address on record to whitelist. Plenty of services accept
+IPv4 only (Azure Key Vault firewall rules are documented as IPv4-only), so a
+dual-stack user ends up whitelisted nowhere on those resources.
+
+Closing that requires a second connection over the other family, because the
+information simply is not present in the first request.
+
+## Decisions
+
+Settled during brainstorming. Each is recorded because it rules out an
+alternative that looks reasonable in isolation.
+
+1. **`url` is fetched by the browser, never by the server.** If the app fetched
+   `ipv4.icanhazip.com` it would learn its own egress address, not the user's.
+   The page therefore fetches and POSTs the result back.
+
+2. **Addresses arriving via `url` are trusted.** This is a real trust inversion:
+   today's address is *observed* by the app and unforgeable, whereas a posted
+   address is a *claim* an authenticated user could fabricate (`{"ipv4":
+   "8.8.8.8"}` via devtools or curl), whitelisting an address they do not
+   control.
+
+   An earlier draft gated this behind a `trust_client: true` flag. That was
+   dropped: the flag would be mandatory-`true` for anyone using `url` at all, so
+   it carried no information. **Setting `url` is itself the opt-in.** The
+   implication is documented at `url` in the README, and a startup log line
+   records which families use client-asserted resolution.
+
+3. **No self-hosted echo endpoint, no nonce.** An alternative had `url` point at
+   the app itself behind v4-only/v6-only DNS names, making the address observed
+   rather than claimed. Rejected: it costs two DNS records plus TLS coverage per
+   deployment, and if those hostnames sit behind Cloudflare Access the probe
+   fetch gets redirected to a login page and fails CORS — which would have
+   needed an unauthenticated nonce-based endpoint to work around. Out of scope.
+   `url` may still point at such an endpoint; it is simply still treated as
+   client-asserted.
+
+4. **Both families default to `enabled: true`.** An earlier sketch defaulted
+   `ipv6` to `false`. That would be a silent regression: today an IPv6-connecting
+   user *is* recorded, and `azure/frontdoor` (which defaults to `ip_version:
+   both`) whitelists them. Defaulting IPv6 off would stop that on upgrade — the
+   same class of bug PR #8 avoided by giving Front Door a `both` default.
+
+5. **`Enabled` is a `*bool`, not a `bool`.** Go's zero value for `bool` is
+   `false`, which would make "omitted" indistinguishable from "explicitly
+   disabled" and silently disable both families for every existing config.
+
+6. **Resolution order is header → connection → url.** The trusted source always
+   wins, and the fetch runs only for a family the connection did not already
+   supply. A v6-connected user therefore probes only for v4, and no third-party
+   request is made for a family already known.
+
+7. **`auth.ip_header` is deprecated, not removed.** It is documented at
+   README:118–134, so it keeps working as the fallback header for any family
+   that specifies none, emitting a deprecation warning. Chosen over a hard break.
+
+8. **Family-suffixed Redis keys, not a multi-valued record.** See *Storage*.
+
+## Capture
+
+### Config schema
+
+```go
+type IpResolution struct {
+    IPv4 IpFamilyResolution `yaml:"ipv4"`
+    IPv6 IpFamilyResolution `yaml:"ipv6"`
+}
+
+type IpFamilyResolution struct {
+    Enabled *bool  `yaml:"enabled"` // pointer: unset (=> true) must differ from false
+    Header  string `yaml:"header"`
+    Url     string `yaml:"url"`
+}
+```
+
+Validation in `config.load()`, matching the existing fatal-on-unsupported-value
+style:
+
+- both families disabled → fatal (nothing could ever be whitelisted)
+- `url` set on a disabled family → fatal (contradictory)
+- `auth.ip_header` still set → deprecation warning
+
+Omitting the `ip_resolution` block entirely must reproduce today's behaviour
+byte for byte: both families enabled, header falling back to `auth.ip_header`
+then `X-Azure-Clientip` then `RemoteAddr`, and no fetches.
+
+### Request flow
+
+The existing server-side path is unchanged:
+
+1. Request lands (`/callback` for `auth.type: azure`, `/` for `none`).
+2. `finishUser` resolves the observed address from header → `RemoteAddr`.
+3. Its family is determined; if that family is enabled, it is whitelisted.
+4. The page renders.
+
+Layered on top:
+
+5. The template emits probe JS only for families that have a `url` **and** were
+   not already satisfied at step 2.
+6. The JS fetches each `url` with a ~5s timeout and
+   `referrerPolicy: 'no-referrer'`.
+7. On success it POSTs `{"family":"ipv6","ip":"2a00:...:1"}` to a new `/resolve`
+   endpoint.
+8. `/resolve` re-derives the user exactly as the index handler does — session
+   for `azure`, identity header for `none` — then validates the claim. Then it
+   whitelists it.
+9. The page text updates to show what was whitelisted.
+
+`/resolve` accepts a claim only when **all** of these hold:
+
+- the caller is authenticated (session token for `azure`, identity header for
+  `none`); otherwise `401`
+- the claimed family is enabled **and has a `url` configured**. Without the
+  second condition `/resolve` would accept claims on deployments that never
+  opted into client-asserted resolution, which would be an open whitelisting
+  endpoint. A claim for a family with no `url` is rejected.
+- the IP parses, and its actual family matches the claimed one
+
+One further tightening: if the `/resolve` request itself arrives over the
+claimed family, the **observed** address wins and the claim is discarded. That
+costs nothing, and it stops a posted claim from overwriting an address the app
+could see for itself.
+
+A failed or timed-out fetch is ignored, logged only to the browser console. A
+user with no IPv6 connectivity will fail the IPv6 probe on every visit; that is
+the normal case, not an error, and must never block the page or the address
+that *was* resolved.
+
+### CORS
+
+Verified 2026-08-24 — `ipv4.icanhazip.com` returns:
+
+```
+access-control-allow-origin: *
+access-control-allow-methods: GET
+```
+
+A plain cross-origin GET `fetch()` can therefore read the body. Because the
+allowed origin is the wildcard, the fetch **must not** set
+`credentials: 'include'` — the Fetch spec rejects that pairing. No credentials
+are wanted regardless.
+
+### What is disclosed to the echo service
+
+A cross-origin `fetch()` runs in CORS mode and sends `Origin:
+https://<your-host>`, so the echo service learns that the hostname exists and
+that a given IP visited it. `Origin` cannot be suppressed without losing the
+ability to read the response. `referrerPolicy: 'no-referrer'` removes `Referer`.
+
+No authentication material can leak: cookies are scoped by domain so
+`CF_Authorization` is never a candidate for a request to `icanhazip.com`;
+`fetch()` defaults to `credentials: 'same-origin'` anyway; and Cloudflare's
+`Cf-*` headers are injected inbound to the app and never exist on the browser's
+outbound request.
+
+## Storage
+
+Redis DB0 gains a family suffix:
+
+| Family | Key            | Note                          |
+|--------|----------------|-------------------------------|
+| IPv4   | `<userkey>`    | unchanged — no migration      |
+| IPv6   | `<userkey>:v6` | new                           |
+
+`u.key` is `[a-z0-9]+` after the regex strip in `finishUser`, so `:` cannot
+collide with a generated key.
+
+Two helpers:
+
+- `redisKey(base string, t IpType) string` — appends `:v6` for IPv6
+- `baseKey(k string) string` — strips the suffix
+
+`r.getGroups()` applies `baseKey()` internally. **This is why no provider needs
+changing**: every provider iterates `w.List`, sees one additional entry, and its
+existing `matchesIpVersion` guard from PR #8 already routes that entry to the
+right resources. All 13 guard sites and all seven `update()` methods stay as
+they are.
+
+Rejected alternatives:
+
+- **One key holding both addresses.** Changes `w.List` from
+  `map[string]string` to `map[string][]string`, touching every guard site and
+  every provider.
+- **A separate Redis DB for IPv6.** `getWhitelist()` would have to merge two
+  DBs into one map, and that map still needs distinct keys per family — so it
+  collapses back into suffixing anyway, plus a fourth connection.
+
+Each family expires independently, which is desirable: if a user's IPv6
+connectivity goes away, that entry ages out on its own while their IPv4 survives.
+
+### Rate limiting
+
+The 120s per-user API throttle (DB2) is keyed on `baseKey`, so one page load
+counts as one call across both families.
+
+No special-casing is required. `whitelist.add()`'s changed-branch does not
+consult `canCallApi`, so a genuinely new IPv6 address pushes to providers
+immediately; only the unchanged-branch — a refresh with the same addresses — is
+throttled. That is already the correct behaviour once `add()` is family-aware.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `config.go` | `IpResolution` struct, defaults, validation, `auth.ip_header` deprecation shim |
+| `http.go` | `/resolve` handler; probe JS in both `indexTempl` and `noAuthTempl` |
+| `user.go` | resolution order in `finishUser`; family determination |
+| `whitelist.go` | family-aware `add()` |
+| `redis.go` | `redisKey` / `baseKey`; `getGroups` normalisation |
+| `config/config.yaml` | new block; fix the now-false "A user has one IP" comment at :79 |
+| `README.md` | document `ip_resolution`, the trust implication of `url`, deprecate `ip_header` |
+| `config.dev/config.yaml` | gitignored — local only, easy to forget |
+
+The Helm chart needs no changes: `templates/config.yaml` passes `.Values.config`
+through verbatim.
+
+## Testing
+
+- **`config_test.go`** — defaults with no block; `*bool` semantics (unset vs
+  `false`); fatal when both families disabled; fatal on `url` with a disabled
+  family; `auth.ip_header` fallback and its deprecation warning.
+- **`redis_test.go`** — per-family keys; independent TTLs; `getGroups`
+  normalisation through `baseKey`.
+- **`whitelist_test.go`** — an IPv6 entry does not clobber the same user's IPv4
+  entry; `add()` per-family change detection.
+- **`http_test.go`** — `/resolve` accepts a valid claim; rejects a family
+  mismatch, an unparseable IP, a disabled family, and a family with no `url`
+  configured; rejects an unauthenticated caller; prefers the observed address
+  when the request arrives over the claimed family.
+- **`functions_test.go`** — `redisKey` / `baseKey` round-trip, including the
+  IPv6-address-as-key case from `auth.type: none`.
+
+## Out of scope
+
+- A self-hosted family-pinned echo endpoint, and the nonce mechanism it would
+  need behind Cloudflare Access (decision 3).
+- Any change to per-resource `ip_version` semantics.
+- Verifying that a target service actually accepts the family we send it —
+  `ip_resolution` and `ip_version` both control what the app *sends*, not what
+  the service accepts. Unchanged from PR #8.

--- a/docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md
@@ -25,10 +25,12 @@ ip_resolution:
     enabled: true
     header: Cf-Connecting-Ip
     url: https://ipv4.icanhazip.com
+    url_timeout: 5s
   ipv6:
     enabled: true
     header: Cf-Connecting-Ip
     url: https://ipv6.icanhazip.com
+    url_timeout: 5s
 ```
 
 `ip_resolution` governs **what we collect**. The existing per-resource
@@ -102,6 +104,19 @@ alternative that looks reasonable in isolation.
 
 8. **Family-suffixed Redis keys, not a multi-valued record.** See *Storage*.
 
+9. **`url_timeout` is a flat sibling of `url`, not a nested `custom_probe`
+   block.** A nested block would put the value three levels deep
+   (`ip_resolution.ipv4.custom_probe.url`) to group exactly two fields, and
+   would nest one of the two peer strategies (`url`) while leaving the other
+   (`header`) flat, hiding their symmetry. The `url_` prefix carries the
+   coupling, and validation covers the rest. If probe options ever multiply,
+   promoting them into a block is mechanical.
+
+10. **`url_timeout` is per family, not one shared value.** A single
+    `ip_resolution.timeout` would be fewer knobs, and since probes run in
+    parallel and failures never block the page there is little practical reason
+    to differ — but per-family costs nothing and keeps the two blocks uniform.
+
 ## Capture
 
 ### Config schema
@@ -113,17 +128,26 @@ type IpResolution struct {
 }
 
 type IpFamilyResolution struct {
-    Enabled *bool  `yaml:"enabled"` // pointer: unset (=> true) must differ from false
-    Header  string `yaml:"header"`
-    Url     string `yaml:"url"`
+    Enabled    *bool  `yaml:"enabled"` // pointer: unset (=> true) must differ from false
+    Header     string `yaml:"header"`
+    Url        string `yaml:"url"`
+    UrlTimeout string `yaml:"url_timeout"` // duration string; resolved to time.Duration at load
 }
 ```
+
+`UrlTimeout` is a `string` run through `time.ParseDuration`, not a
+`time.Duration` field: **yaml.v2 will not parse `5s` into a `Duration`** — it
+only maps integers, and reads them as nanoseconds. Parsing at load with a fatal
+on unparseable input matches the existing `mustResolveIpVersion` convention.
+Defaults to `5s` when unset.
 
 Validation in `config.load()`, matching the existing fatal-on-unsupported-value
 style:
 
 - both families disabled → fatal (nothing could ever be whitelisted)
 - `url` set on a disabled family → fatal (contradictory)
+- `url_timeout` set without `url` → fatal (contradictory)
+- `url_timeout` not parseable by `time.ParseDuration`, or ≤ 0 → fatal
 - `auth.ip_header` still set → deprecation warning
 
 Omitting the `ip_resolution` block entirely must reproduce today's behaviour
@@ -143,8 +167,9 @@ Layered on top:
 
 5. The template emits probe JS only for families that have a `url` **and** were
    not already satisfied at step 2.
-6. The JS fetches each `url` with a ~5s timeout and
-   `referrerPolicy: 'no-referrer'`.
+6. The JS fetches each `url` with that family's `url_timeout` (default `5s`)
+   and `referrerPolicy: 'no-referrer'`. The resolved timeout is rendered into
+   the page, so the browser enforces it via `AbortSignal.timeout()`.
 7. On success it POSTs `{"family":"ipv6","ip":"2a00:...:1"}` to a new `/resolve`
    endpoint.
 8. `/resolve` re-derives the user exactly as the index handler does — session
@@ -264,7 +289,9 @@ through verbatim.
 
 - **`config_test.go`** — defaults with no block; `*bool` semantics (unset vs
   `false`); fatal when both families disabled; fatal on `url` with a disabled
-  family; `auth.ip_header` fallback and its deprecation warning.
+  family; `url_timeout` parsing, its `5s` default, and fatals on an unparseable
+  value, a non-positive value, and `url_timeout` without `url`;
+  `auth.ip_header` fallback and its deprecation warning.
 - **`redis_test.go`** — per-family keys; independent TTLs; `getGroups`
   normalisation through `baseKey`.
 - **`whitelist_test.go`** — an IPv6 entry does not clobber the same user's IPv4

--- a/functions.go
+++ b/functions.go
@@ -134,3 +134,24 @@ func addNetmask(ip string) (string, error) {
 func deleteNetmask(ip string) string {
 	return strings.Split(ip, "/")[0]
 }
+
+// redisKeySuffixV6 distinguishes a user's IPv6 whitelist entry from their IPv4
+// one in Redis DB0. IPv4 keeps the bare user key so entries written before
+// dual-stack support need no migration. A user key is [a-z0-9]+ after the regex
+// strip in finishUser, so ':' can never collide with a generated key.
+const redisKeySuffixV6 = ":v6"
+
+// redisKey returns the DB0 key holding this user's address for family t.
+func redisKey(base string, t IpType) string {
+	if t == IpV6 {
+		return base + redisKeySuffixV6
+	}
+	return base
+}
+
+// baseKey strips any family suffix, returning the plain user key used by the
+// groups cache (DB1) and the API throttle (DB2), both of which are per user
+// rather than per address family.
+func baseKey(k string) string {
+	return strings.TrimSuffix(k, redisKeySuffixV6)
+}

--- a/functions_test.go
+++ b/functions_test.go
@@ -219,3 +219,55 @@ func TestDeleteNetmask(t *testing.T) {
 		}
 	}
 }
+
+func TestRedisKey(t *testing.T) {
+	tests := []struct {
+		base string
+		t    IpType
+		want string
+	}{
+		// ipv4 keeps the bare user key, so existing entries need no migration
+		{"alecpinson123456", IpV4, "alecpinson123456"},
+		{"alecpinson123456", IpV6, "alecpinson123456:v6"},
+		// an unknown family is treated as ipv4 rather than inventing a third key
+		{"alecpinson123456", Undefined, "alecpinson123456"},
+		// auth.type none derives the key from the ip itself; the regex strip in
+		// finishUser leaves only [a-z0-9], so ':' can never collide
+		{"2a001", IpV6, "2a001:v6"},
+	}
+
+	for _, f := range tests {
+		if got := redisKey(f.base, f.t); got != f.want {
+			t.Errorf("redisKey(%q, %v) = %q, want %q", f.base, f.t, got, f.want)
+		}
+	}
+}
+
+func TestBaseKey(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"alecpinson123456", "alecpinson123456"},
+		{"alecpinson123456:v6", "alecpinson123456"},
+		{"2a001:v6", "2a001"},
+		// only a trailing suffix is stripped
+		{"alec:v6user", "alec:v6user"},
+	}
+
+	for _, f := range tests {
+		if got := baseKey(f.in); got != f.want {
+			t.Errorf("baseKey(%q) = %q, want %q", f.in, got, f.want)
+		}
+	}
+}
+
+func TestRedisKeyRoundTrip(t *testing.T) {
+	for _, base := range []string{"alecpinson123456", "2a001", "a"} {
+		for _, ipType := range []IpType{IpV4, IpV6} {
+			if got := baseKey(redisKey(base, ipType)); got != base {
+				t.Errorf("baseKey(redisKey(%q, %v)) = %q, want %q", base, ipType, got, base)
+			}
+		}
+	}
+}

--- a/http.go
+++ b/http.go
@@ -5,8 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -180,6 +182,7 @@ func (a *Authentication) initAzure() {
 	http.Handle("/live", handle(livenessHandler))
 	http.Handle("/ready", handle(readinessHandler))
 	http.Handle("/callback", handle(callbackHandler))
+	http.Handle("/resolve", handle(resolveHandler))
 	http.Handle("/", handle(IndexHandler))
 	log.Fatal(http.ListenAndServe(":8090", nil))
 }
@@ -204,6 +207,7 @@ func noAuthIndexHandler(w http.ResponseWriter, req *http.Request) error {
 func (*Authentication) initNoAuth() {
 	http.Handle("/live", handle(livenessHandler))
 	http.Handle("/ready", handle(readinessHandler))
+	http.Handle("/resolve", handle(resolveHandler))
 	http.Handle("/", handle(noAuthIndexHandler))
 	log.Fatal(http.ListenAndServe(":8090", nil))
 }
@@ -241,6 +245,8 @@ func callbackHandler(w http.ResponseWriter, req *http.Request) error {
 	session.Values["token"] = &token
 	session.Values["name"] = &u.name
 	session.Values["ip_address"] = &u.ip
+	// /resolve needs the whitelist key to rebuild the user
+	session.Values["key"] = u.key
 	if err := sessions.Save(req, w); err != nil {
 		return fmt.Errorf("http.callbackHandler(): error saving session: %v", err)
 	}
@@ -279,6 +285,100 @@ func IndexHandler(w http.ResponseWriter, req *http.Request) error {
 	}
 
 	return indexTempl.Execute(w, &data)
+}
+
+// resolveRequest is a client-asserted address for one family, POSTed by the
+// probe JS after it fetches the configured echo url.
+type resolveRequest struct {
+	Family string `json:"family"`
+	Ip     string `json:"ip"`
+}
+
+// resolveUser rebuilds the authenticated user for a /resolve request without
+// setting an address — the caller supplies that from the claim or the
+// connection. Groups are read back from the cache rather than left nil: w.add()
+// writes u.groups to the cache, so a nil slice here would silently drop the
+// user out of every group-scoped resource.
+func resolveUser(req *http.Request) (*User, error) {
+	switch strings.ToLower(c.Auth.Type) {
+	case "none", "disabled":
+		var u User
+		if u.newFromRequest(req) == nil {
+			return nil, Error{Code: http.StatusUnauthorized, Message: "could not determine client identity"}
+		}
+		return &u, nil
+	default:
+		session, _ := store.Get(req, "session")
+		if session.Values["token"] == nil {
+			return nil, Error{Code: http.StatusUnauthorized}
+		}
+		key, _ := session.Values["key"].(string)
+		if key == "" {
+			return nil, Error{Code: http.StatusUnauthorized}
+		}
+		name, _ := session.Values["name"].(string)
+		return &User{key: key, name: name, groups: r.getGroups(key)}, nil
+	}
+}
+
+// resolveHandler accepts a client-asserted address for one family and
+// whitelists it. The address is a claim the app cannot verify, so it is only
+// accepted for a family that has a url configured — otherwise a deployment that
+// never opted into client-asserted resolution would expose an open whitelisting
+// endpoint.
+func resolveHandler(wr http.ResponseWriter, req *http.Request) error {
+	if req.Method != http.MethodPost {
+		return Error{Code: http.StatusMethodNotAllowed}
+	}
+
+	var body resolveRequest
+	if err := json.NewDecoder(io.LimitReader(req.Body, 1024)).Decode(&body); err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "invalid json"}
+	}
+
+	fr, claimed, ok := c.IpResolution.family(body.Family)
+	if !ok {
+		return Error{Code: http.StatusBadRequest, Message: "unknown address family"}
+	}
+	if !fr.isEnabled() {
+		return Error{Code: http.StatusBadRequest, Message: "address family is disabled"}
+	}
+	if fr.Url == "" {
+		return Error{Code: http.StatusBadRequest, Message: "client-asserted resolution is not configured for this family"}
+	}
+
+	u, err := resolveUser(req)
+	if err != nil {
+		return err
+	}
+
+	ip := body.Ip
+	// if this request itself arrived over the claimed family, the address we
+	// observed is strictly better than the one being claimed
+	if observed := observedIp(req); observed != "" {
+		if t, err := ipVersion(observed); err == nil && t == claimed {
+			ip = observed
+		}
+	}
+
+	t, err := ipVersion(ip)
+	if err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "unparseable ip"}
+	}
+	if t != claimed {
+		return Error{Code: http.StatusBadRequest, Message: "ip does not match the claimed address family"}
+	}
+
+	cidr, err := addNetmask(ip)
+	if err != nil {
+		return Error{Code: http.StatusBadRequest, Message: "unparseable ip"}
+	}
+	u.ip = ip
+	u.cidr = cidr
+	u.whitelist()
+
+	wr.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 func livenessHandler(w http.ResponseWriter, req *http.Request) error {

--- a/http.go
+++ b/http.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gorilla/sessions"
 	_ "golang.org/x/net/context"
@@ -70,6 +71,22 @@ var indexTempl = template.Must(template.New("").Parse(`<!DOCTYPE html>
       });
 {{end}}
     </script>
+{{range .Probes}}
+    <script>
+      (function () {
+        fetch({{.Url}}, {referrerPolicy: 'no-referrer', signal: AbortSignal.timeout({{.Timeout}})})
+          .then(function (res) { return res.ok ? res.text() : Promise.reject(res.status); })
+          .then(function (ip) {
+            return fetch('/resolve', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({family: {{.Family}}, ip: ip.trim()})
+            });
+          })
+          .catch(function (err) { console.log('ip probe failed', err); });
+      })();
+    </script>
+{{end}}
   </body>
 </html>
 `))
@@ -90,6 +107,22 @@ var noAuthTempl = template.Must(template.New("").Parse(`<!DOCTYPE html>
         <i>Note: It can take a few minutes for your whitelisting to become active. Please note that IPv6 cannot be whitelisted on all resources.</i>
       </div>
     </div>
+{{range .Probes}}
+    <script>
+      (function () {
+        fetch({{.Url}}, {referrerPolicy: 'no-referrer', signal: AbortSignal.timeout({{.Timeout}})})
+          .then(function (res) { return res.ok ? res.text() : Promise.reject(res.status); })
+          .then(function (ip) {
+            return fetch('/resolve', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({family: {{.Family}}, ip: ip.trim()})
+            });
+          })
+          .catch(function (err) { console.log('ip probe failed', err); });
+      })();
+    </script>
+{{end}}
   </body>
 </html>
 `))
@@ -197,9 +230,11 @@ func noAuthIndexHandler(w http.ResponseWriter, req *http.Request) error {
 	var data = struct {
 		Name      string
 		IPAddress string
+		Probes    []probe
 	}{
 		Name:      u.name,
 		IPAddress: u.ip,
+		Probes:    pendingProbes(u.ip),
 	}
 	return noAuthTempl.Execute(w, &data)
 }
@@ -274,17 +309,65 @@ func IndexHandler(w http.ResponseWriter, req *http.Request) error {
 		}
 	}
 
+	var probes []probe
+	if token != nil {
+		// before authentication the page only renders a redirect, so there is
+		// nothing to probe for yet
+		probes = pendingProbes(ipAddress)
+	}
+
 	var data = struct {
 		Token     *oauth2.Token
 		AuthURL   string
 		IPAddress string
+		Probes    []probe
 	}{
 		Token:     token,
 		AuthURL:   oauthConfig.AuthCodeURL(SessionState(session), oauth2.AccessTypeOnline),
 		IPAddress: ipAddress,
+		Probes:    probes,
 	}
 
 	return indexTempl.Execute(w, &data)
+}
+
+// probe is one family's browser-side lookup, rendered into the page.
+type probe struct {
+	Family  string
+	Url     string
+	Timeout int // milliseconds, for AbortSignal.timeout()
+}
+
+// pendingProbes returns the lookups the page should run: one per enabled family
+// that has a url configured and was not already satisfied by the connection.
+// The family we observed needs no probe, which also avoids a third-party
+// request for an address we already know.
+func pendingProbes(observed string) []probe {
+	observedType, err := ipVersion(observed)
+	if err != nil {
+		observedType = Undefined
+	}
+
+	var out []probe
+	families := []struct {
+		name string
+		t    IpType
+		fr   IpFamilyResolution
+	}{
+		{ipVersionV4, IpV4, c.IpResolution.IPv4},
+		{ipVersionV6, IpV6, c.IpResolution.IPv6},
+	}
+	for _, f := range families {
+		if !f.fr.isEnabled() || f.fr.Url == "" || f.t == observedType {
+			continue
+		}
+		out = append(out, probe{
+			Family:  f.name,
+			Url:     f.fr.Url,
+			Timeout: int(f.fr.timeout() / time.Millisecond),
+		})
+	}
+	return out
 }
 
 // resolveRequest is a client-asserted address for one family, POSTed by the

--- a/http_test.go
+++ b/http_test.go
@@ -234,6 +234,13 @@ func TestNoAuthIndexHandler(t *testing.T) {
 	defer func() { c.Auth.Header = "" }()
 	c.Auth.IPHeader = "Cf-Connecting-Ip"
 	defer func() { c.Auth.IPHeader = "" }()
+	// set explicitly rather than relying on the zero value: other tests call
+	// c.load(), which populates these headers on the shared global
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+	}
+	defer func() { c.IpResolution = IpResolution{} }()
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Cf-Access-Authenticated-User-Email", "alice@example.com")

--- a/http_test.go
+++ b/http_test.go
@@ -261,3 +261,143 @@ func TestNoAuthIndexHandler(t *testing.T) {
 		t.Errorf("redis whitelist entry = %q, want %q", got, "203.0.113.7/32")
 	}
 }
+
+func TestResolveHandler(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.Auth.Type = "none"
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv4.icanhazip.com"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv6.icanhazip.com"},
+	}
+	defer func() {
+		c.Auth.Type = ""
+		c.Auth.Header = ""
+		c.Auth.IPHeader = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	newReq := func(body string) *http.Request {
+		req := httptest.NewRequest("POST", "/resolve", strings.NewReader(body))
+		req.Header.Set("Cf-Access-Authenticated-User-Email", "bob@example.com")
+		req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+		return req
+	}
+
+	// a valid ipv6 claim from a request that arrived over ipv4 is accepted
+	rr := httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::1"}`)); err != nil {
+		t.Fatalf("resolveHandler() unexpected error: %v", err)
+	}
+	if got := r.getWhitelist()["bobexamplecom"+redisKeySuffixV6]; got != "2a00:11c7:1234:b801::1/128" {
+		t.Errorf("ipv6 entry = %q, want %q", got, "2a00:11c7:1234:b801::1/128")
+	}
+
+	// the claimed family must match the address actually supplied
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"198.51.100.9"}`)); err == nil {
+		t.Error("expected an error for a family mismatch")
+	}
+
+	// unparseable addresses are rejected. This must claim ipv6: the request
+	// arrives over ipv4, so an ipv4 claim would be replaced by the observed
+	// address before it was ever parsed.
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv6","ip":"not-an-ip"}`)); err == nil {
+		t.Error("expected an error for an unparseable ip")
+	}
+
+	// a claim for the family we observed is replaced by the observed address,
+	// which is trustworthy where the claim is not
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv4","ip":"8.8.8.8"}`)); err != nil {
+		t.Fatalf("resolveHandler() unexpected error: %v", err)
+	}
+	if got := r.getWhitelist()["bobexamplecom"]; got != "203.0.113.7/32" {
+		t.Errorf("ipv4 entry = %q, want the observed %q, not the claimed 8.8.8.8", got, "203.0.113.7/32")
+	}
+
+	// an unknown family is rejected
+	rr = httptest.NewRecorder()
+	if err := resolveHandler(rr, newReq(`{"family":"ipv5","ip":"198.51.100.9"}`)); err == nil {
+		t.Error("expected an error for an unknown family")
+	}
+
+	// GET is not allowed
+	rr = httptest.NewRecorder()
+	getReq := httptest.NewRequest("GET", "/resolve", nil)
+	if err := resolveHandler(rr, getReq); err == nil {
+		t.Error("expected an error for a GET request")
+	}
+}
+
+func TestResolveHandlerRejectsUnconfiguredFamily(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.Auth.Type = "none"
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	// no url configured for ipv6 => the deployment never opted into
+	// client-asserted resolution, so /resolve must not act as an open
+	// whitelisting endpoint
+	c.IpResolution = IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"}}
+	defer func() {
+		c.Auth.Type = ""
+		c.Auth.Header = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("POST", "/resolve", strings.NewReader(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::9"}`))
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "carol@example.com")
+	rr := httptest.NewRecorder()
+
+	if err := resolveHandler(rr, req); err == nil {
+		t.Error("expected an error for a family with no url configured")
+	}
+	if got := r.getWhitelist()["carolexamplecom"+redisKeySuffixV6]; got != "" {
+		t.Errorf("unconfigured family should not be stored, got %q", got)
+	}
+}
+
+func TestResolveHandlerRejectsUnauthenticated(t *testing.T) {
+	// azure mode with no session token: /resolve must not whitelist anything
+	store = sessions.NewFilesystemStore(t.TempDir(), sessionStoreKeyPairs...)
+	c.Auth.Type = "azure"
+	c.IpResolution = IpResolution{IPv6: IpFamilyResolution{Url: "https://ipv6.icanhazip.com"}}
+	defer func() {
+		c.Auth.Type = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("POST", "/resolve", strings.NewReader(`{"family":"ipv6","ip":"2a00:11c7:1234:b801::3"}`))
+	rr := httptest.NewRecorder()
+
+	err := resolveHandler(rr, req)
+	if err == nil {
+		t.Fatal("expected an error for an unauthenticated caller")
+	}
+	httpErr, ok := err.(Error)
+	if !ok || httpErr.Code != http.StatusUnauthorized {
+		t.Errorf("error = %v, want a 401", err)
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/sessions"
 	"golang.org/x/oauth2"
@@ -399,5 +400,92 @@ func TestResolveHandlerRejectsUnauthenticated(t *testing.T) {
 	httpErr, ok := err.(Error)
 	if !ok || httpErr.Code != http.StatusUnauthorized {
 		t.Errorf("error = %v, want a 401", err)
+	}
+}
+
+func TestPendingProbes(t *testing.T) {
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"},
+		IPv6: IpFamilyResolution{Url: "https://ipv6.icanhazip.com"},
+	}
+
+	// connected over ipv4 => only the ipv6 probe is pending
+	probes := pendingProbes("203.0.113.7")
+	if len(probes) != 1 || probes[0].Family != ipVersionV6 {
+		t.Errorf("pendingProbes(ipv4 client) = %+v, want one ipv6 probe", probes)
+	}
+	if probes[0].Timeout != int(defaultUrlTimeout/time.Millisecond) {
+		t.Errorf("timeout = %d ms, want %d ms", probes[0].Timeout, int(defaultUrlTimeout/time.Millisecond))
+	}
+
+	// connected over ipv6 => only the ipv4 probe is pending
+	probes = pendingProbes("2a00:11c7:1234:b801::1")
+	if len(probes) != 1 || probes[0].Family != ipVersionV4 {
+		t.Errorf("pendingProbes(ipv6 client) = %+v, want one ipv4 probe", probes)
+	}
+
+	// a family with no url is never probed
+	c.IpResolution = IpResolution{IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"}}
+	if probes := pendingProbes("203.0.113.7"); len(probes) != 0 {
+		t.Errorf("pendingProbes() = %+v, want none", probes)
+	}
+
+	// a disabled family is never probed
+	disabled := false
+	c.IpResolution = IpResolution{
+		IPv6: IpFamilyResolution{Enabled: &disabled, Url: ""},
+		IPv4: IpFamilyResolution{Url: "https://ipv4.icanhazip.com"},
+	}
+	if probes := pendingProbes("2a00:11c7:1234:b801::1"); len(probes) != 1 {
+		t.Errorf("pendingProbes() = %+v, want just the ipv4 probe", probes)
+	}
+}
+
+func TestNoAuthIndexHandlerRendersProbe(t *testing.T) {
+	testRedisInstance := CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.Auth.Header = "Cf-Access-Authenticated-User-Email"
+	c.Auth.IPHeader = "Cf-Connecting-Ip"
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip", Url: "https://ipv6.icanhazip.com"},
+	}
+	defer func() {
+		c.Auth.Header = ""
+		c.Auth.IPHeader = ""
+		c.IpResolution = IpResolution{}
+	}()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Access-Authenticated-User-Email", "dave@example.com")
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+	rr := httptest.NewRecorder()
+
+	if err := noAuthIndexHandler(rr, req); err != nil {
+		t.Fatalf("noAuthIndexHandler() unexpected error: %v", err)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "ipv6.icanhazip.com") {
+		t.Errorf("body missing the ipv6 probe url:\n%s", body)
+	}
+	if !strings.Contains(body, "/resolve") {
+		t.Errorf("body missing the /resolve POST:\n%s", body)
+	}
+	// the ipv4 address came from the connection, so it must not be probed for
+	if strings.Contains(body, "ipv4.icanhazip.com") {
+		t.Errorf("body should not probe for the family already observed:\n%s", body)
 	}
 }

--- a/redis.go
+++ b/redis.go
@@ -179,6 +179,10 @@ func (r RedisConfiguration) setGroupExpiry(user string) bool {
 
 // get groups
 func (r RedisConfiguration) getGroups(user string) []string {
+	// w.List keys carry a family suffix, but the groups cache is per user —
+	// normalising here is what lets every provider stay unchanged.
+	user = baseKey(user)
+
 	var g []string
 
 	redisResponse1 := time.Now()

--- a/redis_test.go
+++ b/redis_test.go
@@ -290,6 +290,31 @@ func TestGetGroupsMissing(t *testing.T) {
 	DeleteTestRedis(t, testRedisInstance)
 }
 
+func TestGetGroupsIgnoresFamilySuffix(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	if r.connect(rc) {
+		const user = "testuser111111"
+		if !r.addGroups(user, []string{"group1", "group2"}) {
+			t.Fatal("failed to seed groups")
+		}
+
+		// providers read keys straight out of w.List, which now contains
+		// family-suffixed entries; both forms must find the same cached groups
+		if got := r.getGroups(user); len(got) != 2 {
+			t.Errorf("getGroups(%q) = %v, want 2 groups", user, got)
+		}
+		if got := r.getGroups(user + redisKeySuffixV6); len(got) != 2 {
+			t.Errorf("getGroups(%q) = %v, want 2 groups", user+redisKeySuffixV6, got)
+		}
+	}
+
+	DeleteTestRedis(t, testRedisInstance)
+}
+
 func TestGetGroups(t *testing.T) {
 	users := []struct {
 		user    string

--- a/user.go
+++ b/user.go
@@ -96,26 +96,31 @@ func (u *User) new(client *http.Client, req *http.Request) *User {
 	return u
 }
 
+// observedIp returns the client address as the app sees it: the first
+// ip_resolution header that is present, falling back to RemoteAddr. This is the
+// trusted path — the value is something the app or its proxy observed, not
+// something the client asserted.
+func observedIp(req *http.Request) string {
+	for _, header := range c.IpResolution.headers() {
+		if v := req.Header.Get(header); v != "" {
+			return v
+		}
+	}
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		log.Printf("user.observedIp(): %q is not IP:port\n", req.RemoteAddr)
+		return ""
+	}
+	return ip
+}
+
 // finishUser fills in the request-derived fields shared by both the OAuth and
 // no-auth constructors: the client IP (with a loopback override for local
 // testing), its cidr, and the whitelist key derived from identity. When
 // identity is empty the key falls back to the client IP.
 func (u *User) finishUser(identity string, req *http.Request) error {
-	// get ip from the configured trusted header. Azure Front Door sets
-	// X-Azure-Clientip (the default when ip_header is unset); no-auth mode uses
-	// ip_header (e.g. Cf-Connecting-Ip). Fall back to RemoteAddr when absent.
-	ipHeader := c.Auth.IPHeader
-	if ipHeader == "" {
-		ipHeader = "X-Azure-Clientip"
-	}
-	u.ip = req.Header.Get(ipHeader)
-	if u.ip == "" {
-		var err error
-		u.ip, _, err = net.SplitHostPort(req.RemoteAddr)
-		if err != nil {
-			log.Printf("user.finishUser(): %q is not IP:port\n", req.RemoteAddr)
-		}
-	}
+	// the client IP as observed by the app or its trusted proxy
+	u.ip = observedIp(req)
 
 	// annoying when testing locally, make up an ip :)
 	if u.ip == "::1" {

--- a/user_test.go
+++ b/user_test.go
@@ -279,3 +279,46 @@ func TestUserNewErrorStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestObservedIp(t *testing.T) {
+	defer func() { c.IpResolution = IpResolution{}; c.Auth.IPHeader = "" }()
+
+	// a per-family header is read
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+		IPv6: IpFamilyResolution{Header: "Cf-Connecting-Ip"},
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Cf-Connecting-Ip", "203.0.113.7")
+	if got := observedIp(req); got != "203.0.113.7" {
+		t.Errorf("observedIp() = %q, want %q", got, "203.0.113.7")
+	}
+
+	// the two families may name different headers; both are tried, ipv4 first
+	c.IpResolution = IpResolution{
+		IPv4: IpFamilyResolution{Header: "X-V4-Ip"},
+		IPv6: IpFamilyResolution{Header: "X-V6-Ip"},
+	}
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-V6-Ip", "2a00:11c7:1234:b801::1")
+	if got := observedIp(req); got != "2a00:11c7:1234:b801::1" {
+		t.Errorf("observedIp() = %q, want the ipv6 header value", got)
+	}
+
+	// with no header present, fall back to RemoteAddr
+	c.IpResolution = IpResolution{}
+	req = httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "198.51.100.9:54321"
+	if got := observedIp(req); got != "198.51.100.9" {
+		t.Errorf("observedIp() = %q, want %q", got, "198.51.100.9")
+	}
+
+	// the deprecated auth.ip_header still works when no family names one
+	c.IpResolution = IpResolution{}
+	c.Auth.IPHeader = "X-Legacy-Ip"
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Legacy-Ip", "203.0.113.8")
+	if got := observedIp(req); got != "203.0.113.8" {
+		t.Errorf("observedIp() = %q, want %q", got, "203.0.113.8")
+	}
+}

--- a/whitelist.go
+++ b/whitelist.go
@@ -41,19 +41,32 @@ func (w *Whitelist) add(u *User) bool {
 		return false
 	}
 
+	t, err := ipVersion(u.cidr)
+	if err != nil {
+		log.Printf("whitelist.add(): %v", err)
+		return false
+	}
+	if !c.IpResolution.enabledFor(t) {
+		log.Println("whitelist.add(): ip_resolution is disabled for this address family, skipping " + u.ip)
+		return false
+	}
+	// the groups cache and api throttle stay keyed per user; only the address
+	// itself is stored per family
+	key := redisKey(u.key, t)
+
 	ret := r.addGroups(u.key, u.groups)
 	if !ret {
 		return ret
 	}
 
-	if w.List[u.key] != u.cidr {
+	if w.List[key] != u.cidr {
 		// need to update list
-		if w.List[u.key] == "" {
-			log.Println("whitelist.add(): no current whitelist for '" + u.key + "' was found, adding ip " + u.ip)
+		if w.List[key] == "" {
+			log.Println("whitelist.add(): no current whitelist for '" + key + "' was found, adding ip " + u.ip)
 		} else {
-			log.Println("whitelist.add(): updating whitelist for '" + u.key + "' from " + w.List[u.key] + " to " + u.ip)
+			log.Println("whitelist.add(): updating whitelist for '" + key + "' from " + w.List[key] + " to " + u.ip)
 		}
-		ret = r.addIp(u.key, u.cidr)
+		ret = r.addIp(key, u.cidr)
 		if !ret {
 			return ret
 		}
@@ -62,19 +75,21 @@ func (w *Whitelist) add(u *User) bool {
 		return true
 	} else {
 		// ip already whitelisted ... renew redis expiry time though
-		log.Println("whitelist.add(): no changes required for '" + u.key + "', ip already set to " + u.ip)
+		log.Println("whitelist.add(): no changes required for '" + key + "', ip already set to " + u.ip)
 		if r.canCallApi(u.key) {
 			r.apiCalled(u.key)
 			go w.updateResources()
 		}
-		return r.setIpExpiry(u.key)
+		return r.setIpExpiry(key)
 	}
 }
 
 func (w *Whitelist) delete(u *User) bool {
-	ret := r.deleteIp(u.key)
-	if !ret {
-		return ret
+	// a user may hold one entry per address family
+	for _, t := range []IpType{IpV4, IpV6} {
+		if !r.deleteIp(redisKey(u.key, t)) {
+			return false
+		}
 	}
 	w.updateResources()
 	log.Println("whitelist.delete(): whitelisting for '" + u.key + "' removed.")

--- a/whitelist_test.go
+++ b/whitelist_test.go
@@ -121,3 +121,66 @@ func TestInRange(t *testing.T) {
 		}
 	}
 }
+
+func TestAddDualStack(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	c.IpResolution = IpResolution{}
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+
+	v4 := &User{key: "dualstackuser", ip: "203.0.113.7", cidr: "203.0.113.7/32"}
+	v6 := &User{key: "dualstackuser", ip: "2a00:11c7:1234:b801::1", cidr: "2a00:11c7:1234:b801::1/128"}
+
+	if !w.add(v4) {
+		t.Fatal("adding the ipv4 address failed")
+	}
+	if !w.add(v6) {
+		t.Fatal("adding the ipv6 address failed")
+	}
+
+	list := r.getWhitelist()
+	if got := list["dualstackuser"]; got != "203.0.113.7/32" {
+		t.Errorf("ipv4 entry = %q, want %q", got, "203.0.113.7/32")
+	}
+	if got := list["dualstackuser"+redisKeySuffixV6]; got != "2a00:11c7:1234:b801::1/128" {
+		t.Errorf("ipv6 entry = %q, want %q", got, "2a00:11c7:1234:b801::1/128")
+	}
+}
+
+func TestAddSkipsDisabledFamily(t *testing.T) {
+	var testRedisInstance = CreateTestRedis(t)
+	var rc RedisConfiguration
+	rc.Host = testRedisInstance.Host
+	rc.Port = testRedisInstance.Port
+	rc.Token = testRedisInstance.Token
+	defer DeleteTestRedis(t, testRedisInstance)
+
+	c.TTL = 24
+	c.IPWhiteList = nil
+	disabled := false
+	c.IpResolution = IpResolution{IPv6: IpFamilyResolution{Enabled: &disabled}}
+	defer func() { c.IpResolution = IpResolution{} }()
+
+	if !r.connect(rc) {
+		t.Fatal("could not connect to test redis")
+	}
+
+	v6 := &User{key: "disabledfamilyuser", ip: "2a00:11c7:1234:b801::2", cidr: "2a00:11c7:1234:b801::2/128"}
+	if w.add(v6) {
+		t.Error("add() should refuse an address whose family is disabled")
+	}
+	if got := r.getWhitelist()["disabledfamilyuser"+redisKeySuffixV6]; got != "" {
+		t.Errorf("disabled family should not be stored, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Lets one user hold both an IPv4 and an IPv6 whitelist entry at the same time, instead of only whichever family their browser connected over. This is the follow-up PR #8 deliberately deferred.

Two independent halves:

- **Storage** — Redis DB0 gains a `:v6` key suffix so an IPv6 entry no longer overwrites the same user's IPv4 entry. IPv4 keeps the bare key, so **no migration is needed**. `getGroups()` normalises the suffix away, which is why **no provider changed**: they iterate `w.List`, see one extra entry, and PR #8's `matchesIpVersion` guards already route it correctly.
- **Capture** — a new top-level `ip_resolution` block describes per family how to learn an address: a trusted proxy `header` (today's behaviour), and/or a `url` fetched **by the browser** against a family-pinned echo service, POSTed back to a new `/resolve` endpoint.

Omitting the block entirely reproduces current behaviour byte for byte, so upgrading is a no-op.

```yaml
ip_resolution:
  ipv4:
    enabled: true                     # default true
    header: Cf-Connecting-Ip
    url: https://ipv4.icanhazip.com   # optional
    url_timeout: 5s                   # optional, default 5s
  ipv6:
    enabled: true
    header: Cf-Connecting-Ip
    url: https://ipv6.icanhazip.com
    url_timeout: 5s
```

`ip_resolution` controls what we **collect**; a resource's `ip_version` controls where we **send** it. Orthogonal.

## Trust model — please read

`header` is trusted (observed by the app or its proxy, unforgeable). `url` is **not**: the address comes back as a claim the app cannot verify, so an authenticated user could whitelist an address they don't control. Setting `url` is the opt-in; the app logs which families use it at startup. Where the app can see the address itself, the observed value always wins over the claim.

`/resolve` only accepts a claim for a family that has a `url` **configured** — otherwise it would be an open whitelisting endpoint on deployments that never opted in.

`auth.ip_header` is deprecated but still honoured as a fallback, with a startup warning.

## Test Plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passing (~98s, Docker-backed Redis tests included)
- [x] `helm lint helm/ip-whitelister` passing — chart needed no changes, it passes `.Values.config` through verbatim
- [x] Pre-existing `TestAdd`, `TestDelete`, `TestIndexHandler`, `TestNoAuthIndexHandler`, `TestLoad` all still pass
- [ ] **Not yet verified in a browser** — the probe JS, `AbortSignal.timeout()`, and icanhazip's CORS from a real page have only been unit-tested. To be validated on k3s.

Spec: `docs/superpowers/specs/2026-08-24-dual-stack-ip-resolution-design.md`
Plan: `docs/superpowers/plans/2026-08-24-dual-stack-ip-resolution.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)